### PR TITLE
Fix unhandled exception in get_test_run

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -22,6 +22,8 @@ Test dependencies
 
 * testscenarios (https://launchpad.net/testscenarios).
 
+* mock (https://pypi.python.org/pypi/mock).
+
 Installing
 ~~~~~~~~~~
 

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ setup(name='testrepository',
             'pytz',
             'testresources',
             'testscenarios',
+            'mock',
             ]
         ),
       entry_points={

--- a/testrepository/repository/file.py
+++ b/testrepository/repository/file.py
@@ -133,6 +133,8 @@ class Repository(AbstractRepository):
         except IOError as e:
             if e.errno == errno.ENOENT:
                 raise KeyError("No such run.")
+            else:
+                raise
         return _DiskRun(run_id, run_subunit_content)
 
     def _get_inserter(self, partial):

--- a/testrepository/tests/repository/test_file.py
+++ b/testrepository/tests/repository/test_file.py
@@ -19,6 +19,7 @@ import shutil
 import tempfile
 
 from fixtures import Fixture
+import mock
 from testtools.matchers import Raises, MatchesException
 
 from testrepository.repository import file
@@ -100,3 +101,9 @@ class TestFileRepository(ResourcedTestCase):
         open(os.path.join(repo.base, 'next-stream'), 'wb').close()
         self.assertThat(repo.count, Raises(
             MatchesException(ValueError("Corrupt next-stream file: ''"))))
+
+    def test_get_test_run_unexpected_ioerror_errno(self):
+        repo = self.useFixture(FileRepositoryFixture(self)).repo
+        with mock.patch('__builtin__.open', mock.mock_open()) as open_patch:
+            open_patch.side_effect = IOError()
+            self.assertRaises(IOError, repo.get_test_run, 'test_fake')


### PR DESCRIPTION
This commit fixes the case when the open in get_test_run() raises an
exception besides IOError.

Closes-Bug: #1409936