### PR TITLE
Add coverage package name

### DIFF
--- a/testrepository/setuptools_command.py
+++ b/testrepository/setuptools_command.py
@@ -42,6 +42,7 @@ class Testr(cmd.Command):
          "from each testr worker."),
         ('testr-args=', 't', "Run 'testr' with these args"),
         ('omit=', 'o', 'Files to omit from coverage calculations'),
+        ('coverage-package-name=', None, "Use this name for coverage package"),
         ('slowest', None, "Show slowest test times after tests complete."),
     ]
 
@@ -56,6 +57,7 @@ class Testr(cmd.Command):
         self.coverage = None
         self.omit = ""
         self.slowest = None
+        self.coverage_package_name = None
 
     def finalize_options(self):
         if self.testr_args is None:
@@ -86,6 +88,10 @@ class Testr(cmd.Command):
         package = self.distribution.get_name()
         if package.startswith('python-'):
             package = package[7:]
+
+        # Use this as coverage package name
+        if self.coverage_package_name:
+            package = self.coverage_package_name
         options = "--source %s --parallel-mode" % package
         os.environ['PYTHON'] = ("coverage run %s" % options)
 


### PR DESCRIPTION
Allow to specify a different package name than the one from the setp.cfg
project.

Fixes https://bugs.launchpad.net/testrepository/+bug/1298398

Moved from https://code.launchpad.net/~chmouel/testrepository/coverage-package-name/+merge/213218 to GitHub.

Cc: @rbtcollins 