### PR TITLE
profiles for e.g. testing with multiple Python versions

### DIFF
--- a/.testr.conf
+++ b/.testr.conf
@@ -3,3 +3,7 @@ test_command=${PYTHON:-python} -m subunit.run discover $LISTOPT $IDOPTION
 test_id_option=--load-list $IDFILE
 test_list_option=--list
 ;filter_tags=worker-0
+list_profiles=echo 2.6 2.7 3.2 3.3 3.4 3.5 cpython pypy pypy3
+instance_provision=tools/start-container $INSTANCE_PROFILE $INSTANCE_COUNT
+;instance_dispose=
+instance_execute=tools/run-container $INSTANCE_PROFILE $INSTANCE_ID $FILES -- $COMMAND

--- a/.testr.conf
+++ b/.testr.conf
@@ -1,9 +1,9 @@
 [DEFAULT]
-test_command=${PYTHON:-python} -m subunit.run discover $LISTOPT $IDOPTION
+test_command=${PYTHON:-python} -m subunit.run discover $LISTOPT $IDOPTION ${PROFILE:+ | subunit-tags $PROFILE}
 test_id_option=--load-list $IDFILE
 test_list_option=--list
 ;filter_tags=worker-0
 list_profiles=echo 2.6 2.7 3.2 3.3 3.4 3.5 cpython pypy pypy3
-instance_provision=tools/start-container $INSTANCE_PROFILE $INSTANCE_COUNT
+instance_provision=tools/start-container $PROFILE $INSTANCE_COUNT
 ;instance_dispose=
-instance_execute=tools/run-container $INSTANCE_PROFILE $INSTANCE_ID $FILES -- $COMMAND
+instance_execute=tools/run-container $PROFILE $INSTANCE_ID $FILES -- $COMMAND

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -11,6 +11,8 @@ Run time dependencies
 * fixtures (https://launchpad.net/python-fixtures, or
    http://pypi.python.org/pypi/fixtures/).
 
+* six.
+
 Test dependencies
 ~~~~~~~~~~~~~~~~~
 

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,8 @@ editable:
 	./testr init
 
 check: editable .testrepository
-	./testr run --parallel
+	# Run without containers/multiple profiles by default.
+	./testr run --parallel -p DEFAULT
 
 check-xml:
 	python -m subunit.run testrepository.tests.test_suite | subunit2junitxml -o test.xml -f | subunit2pyunit

--- a/Makefile
+++ b/Makefile
@@ -33,4 +33,12 @@ release:
 README.rst: editable testrepository/commands/quickstart.py
 	./testr quickstart > $@
 
-.PHONY: check check-xml editable release all
+${venv}/testr-installed-stamp: requirements.txt setup.cfg
+	${venv}/bin/pip -q install -e .[test]
+	touch ${venv}/testr-installed-stamp
+
+
+install-for-test: ${venv}/testr-installed-stamp
+	@#  nothing
+
+.PHONY: check check-xml editable install-for-test release all

--- a/doc/DEVELOPERS.txt
+++ b/doc/DEVELOPERS.txt
@@ -47,6 +47,16 @@ configuration is needed - creating virtualenvs with names that inform the
 tools of the container name to use. The profile 'DEFAULT' will bypass the
 container glue and run in the local environment.
 
+Specifically, the current scripts assume virtualenvs in ~/.virtualenvs (like
+virtualenv-wrappers creates), and a name of testrepository-$profile-hostname,
+with 'ssh hostname' being something that works.
+
+So to run the full test matrix for testrepository, create one lxc container
+for each Linux distribution you need in order to have Python 2.6, 2.7, 3.2,
+3.3, 3.4, 3.5, cpython(e.g. master), pypy and pypy3, and then create one
+virtualenv for each of the versions to test in ~/.virtualenvs, named
+testrepository-$version-$lxchostname. Finally, run `testr run`.
+
 Diagnosing issues
 -----------------
 

--- a/doc/DEVELOPERS.txt
+++ b/doc/DEVELOPERS.txt
@@ -39,7 +39,13 @@ Running the tests
 
 Generally just ``make`` is all that is needed to run all the tests. However
 if dropping into pdb, it is currently more convenient to use
-``python -m testtools.run testrepository.tests.test_suite``.
+``python -m testtools.run discover``.
+
+The tools in ``tools/`` can run up lxc containers to run different versions of
+Python transparently using the in-built profile support. Some local
+configuration is needed - creating virtualenvs with names that inform the
+tools of the container name to use. The profile 'DEFAULT' will bypass the
+container glue and run in the local environment.
 
 Diagnosing issues
 -----------------

--- a/doc/MANUAL.txt
+++ b/doc/MANUAL.txt
@@ -226,17 +226,27 @@ class (the last . splits the class and test method)::
     group_regex=([^\.]+\.)+
 
 
-Remote or isolated test environments
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Profiles and remote or isolated test environments
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-A common problem with parallel test running is test runners that use global
-resources such as well known ports, well known database names or predictable
-directories on disk. 
+A common testing problem is testing the same code against a matrix of
+test scenarios. For instance with a C program you may wish to test against
+both `clang` and `gcc`. In Python you may wish to test against multiple
+releases of cPython, or against different Python implementations, or both.
+
+Testr delegates the creation of such a test matrix to you, but will request a
+separate test environment for each *profile*.
+
+Another common issue occurs with with parallel test running where test runners
+that use global resources such as well known ports, well known database names
+or predictable directories on disk. 
 
 One way to solve this is to setup isolated environments such as chroots,
 containers or even separate machines. Such environments typically require
 some coordination when being used to run tests, so testr provides an explicit
-model for working with them.
+model for instantiating and disposing of such test environments. Testr does
+not differentiate between running commands in a regular subprocess, or via ssh
+to an arbitrary endpoint: they are all just test environments.
 
 The model testr has is intended to support both developers working
 incrementally on a change and CI systems running tests in a one-off setup,
@@ -249,62 +259,81 @@ The process testr follows is:
    credentials.
 2. Execute testr run.
 3. testr queries for concurrency.
-4. testr will make a callout request to provision that many instances.
-   The provisioning callout needs to synchronise source code and do any other
-   per-instance setup at this stage.
-5. testr will make callouts to execute tests, supplying files that should be
+4. testr queries for available profiles.
+5. If testr needs to query test ids, it will provision one instance for each
+   profile, and use that instance to query test ids **per profile**. NB: until
+   testr gets an online scheduler, it will loop around the profiles one at a
+   time.
+6. testr will then provision as many instances as needed to execute the tests.
+   The provisioning callout involves to synchronising source code and do any
+   other per-instance.
+7. testr will make callouts to execute tests, supplying files that should be
    copied into the execution environment. Note that instances may be used for
    more than one command execution.
-6. testr will callout to dispose of the instances after the test run completes.
+8. testr will callout to dispose of the instances after the instance is no
+   longer needed.
 
 Instances may be expensive to create and dispose of. testr does not perform
 any caching, but the callout pattern is intended to facilitate external
 caching - the provisioning callout can be used to pull environments out of
 a cache, and the dispose to just return it to the cache.
 
-Configuring environment support
--------------------------------
+Configuring profiles and environments
+-------------------------------------
 
-There are three callouts that testrepository depends on - configured in
+There are five callouts that testrepository depends on - configured in
 .testr.conf as usual. For instance::
 
-  instance_provision=foo -c $INSTANCE_COUNT
-  instance_dispose=bar $INSTANCE_IDS
-  instance_execute=quux $INSTANCE_ID $FILES -- $COMMAND
+  list_profiles=echo py27 py34
+  default_profiles=echo py27
+  instance_provision=foo -c $INSTANCE_COUNT $INSTANCE_PROFILE
+  instance_dispose=bar $INSTANCE_PROFILE $INSTANCE_IDS 
+  instance_execute=quux $INSTANCE_PROFILE $INSTANCE_ID $FILES -- $COMMAND
 
 These should operate as follows:
 
+* list_profiles should return profile names. Profile names are simple text
+  with whitespace between them. list_profiles should return all the profiles
+  available to the test run: missing profiles will cause errors when users
+  request them.
+
+* default_profiles should also return profile names to run tests in. If it is
+  not configured or returns an empty output, then all the profiles returned by
+  list_profiles are used. Users can use the ``--profiles`` option to override
+  the value of default_profiles.
+
 * instance_provision should start up the number of instances provided in the
-  $INSTANCE_COUNT parameter. It should print out on stdout the instance ids
-  that testr should supply to the dispose and execute commands. There should
-  be no other output on stdout (stderr is entirely up for grabs). An exit code
-  of non-zero will cause testr to consider the command to have failed. A
-  provisioned instance should be able to execute the list tests command and
-  execute tests commands that testr will run via the instance_execute callout.
-  Its possible to lazy-provision things if you desire - testr doesn't care -
-  but to reduce latency we suggest performing any rsync or other code
-  synchronisation steps during the provision step, as testr may make multiple
-  calls to one environment, and re-doing costly operations on each command
-  execution would impair performance.
+  $INSTANCE_COUNT parameter suitable for running the $INSTANCE_PROFILE
+  environment. It should print out on stdout the instance ids that testr
+  should supply to the dispose and execute commands. These are scoped by
+  testr to the profile (they may overlap those from a different profile).
+  There should be no other output on stdout (stderr is entirely up for grabs).
+  An exit code of non-zero will cause testr to consider the command to have
+  failed. A provisioned instance should be able to execute the list tests
+  command and execute tests commands that testr will run via the
+  instance_execute callout.  Its possible to lazy-provision things if you
+  desire - testr doesn't care - but to reduce latency we suggest performing
+  any rsync or other code synchronisation steps during the provision step, as
+  testr may make multiple calls to one environment, and re-doing costly
+  operations on each command execution would impair performance.
 
 * instance_dispose should take a list of instance ids and get rid of them
   this might mean putting them back in a pool of instances, or powering them
   off, or terminating them - whatever makes sense for your project.
 
-* instance_execute should accept an instance id, a list of files that need to 
-  be copied into the instance and a command to run within the instance. It
-  needs to copy those files into the instance (it may adjust their paths if
-  desired). If the paths are adjusted, the same paths within $COMMAND should be
-  adjusted to match. Execution that takes place with a shared filesystem can
-  obviously skip file copying or adjusting (and the $FILES parameter). When the
-  instance_execute terminates, it should use the exit code that the command
-  used within the instance. Stdout and stderr from instance_execute are
-  presumed to be that of $COMMAND. In particular, stdout is where the subunit
-  test output, and subunit test listing output, are expected, and putting other
-  output into stdout can lead to surprising results - such as corrupting the
-  subunit stream.
-  instance_execute is invoked for both test listing and test executing
-  callouts.
+* instance_execute should accept an instance id, a profile name and a list of
+  files that need to be copied into the instance and a command to run within
+  the instance. It needs to copy those files into the instance (it may adjust
+  their paths if desired). If the paths are adjusted, the same paths within
+  $COMMAND should be adjusted to match. Execution that takes place with a
+  shared filesystem can obviously skip file copying or adjusting (and the
+  $FILES parameter).  When the instance_execute terminates, it should use the
+  exit code that the command used within the instance. Stdout and stderr from
+  instance_execute are presumed to be that of $COMMAND. In particular, stdout
+  is where the subunit test output, and subunit test listing output, are
+  expected, and putting other output into stdout can lead to surprising
+  results - such as corrupting the subunit stream.  instance_execute is
+  invoked for both test listing and test executing callouts.
 
 Hiding tests
 ~~~~~~~~~~~~

--- a/doc/MANUAL.txt
+++ b/doc/MANUAL.txt
@@ -273,9 +273,9 @@ both `clang` and `gcc`. In Python you may wish to test against multiple
 releases of cPython, or against different Python implementations, or both.
 
 Testr delegates the creation of such a test matrix to you. When test
-identifiers are supplied to testr on either the command line or
-listing files, they may be namespaced with a particular test profile.
-If they are not namespaced, they will be applied to all profiles.
+identifiers are supplied to testr via listing files, they may be tagged with a
+particular test profile. If they are not tagged, they will be applied to all
+profiles.
 
 Another common issue occurs with with parallel test running where test runners
 that use global resources such as well known ports, well known database names

--- a/doc/MANUAL.txt
+++ b/doc/MANUAL.txt
@@ -188,6 +188,10 @@ by ``testr list-tests myfilter``. As with 'run', arguments to 'list-tests' are
 used to regex filter the tests of the test runner, and arguments after a '--'
 are passed to the test runner.
 
+``testr list-tests --json`` will output the tests as structured data, allowing
+reporting on which profiles the tests are found in. The current schema is
+`{test: {profiles: [profilename, ...]}}`.
+
 Parallel testing
 ~~~~~~~~~~~~~~~~
 

--- a/doc/MANUAL.txt
+++ b/doc/MANUAL.txt
@@ -32,6 +32,40 @@ Most commands in testr have comprehensive online help, and the commands::
 
 Will be useful to explore the system.
 
+Concepts
+~~~~~~~~
+
+Repository
+----------
+
+A store of the output from tests that were run, which can be datamined.
+Defaults to `./.testrepository`.
+
+Subunit stream
+--------------
+
+A structured format for representing the activity that occurs during a test
+run. See the subunit project documentation for more information.
+
+Test profile
+------------
+
+A particular configuration that tests are being run under.
+
+Test id
+-------
+
+The identifier for a test. These should uniquely identify a single test that
+is going to be run. Id's are simple unicode strings that may contain
+whitespace but not newlines.
+
+Test runner
+-----------
+
+The thing responsible for running your test suite and generating a subunit
+stream. Test repository includes an (optional) runner with the `run` and
+`list-tests` commands.
+
 Configuration
 ~~~~~~~~~~~~~
 
@@ -40,6 +74,10 @@ directory that testr is run from. testr includes online help for all the
 options that can be set within it::
 
   $ testr help run
+
+Currently all the configuration pertains to the (optional) testrepository
+runner. The `load`, `failing`, `last` and other query commands work on the
+data store don't have configuration.
 
 Python
 ------

--- a/doc/MANUAL.txt
+++ b/doc/MANUAL.txt
@@ -282,7 +282,9 @@ Configuring profiles and environments
 -------------------------------------
 
 There are five callouts that testrepository depends on - configured in
-.testr.conf as usual. For instance::
+.testr.conf as usual.
+
+For instance::
 
   list_profiles=echo py27 py34
   default_profiles=echo py27

--- a/doc/MANUAL.txt
+++ b/doc/MANUAL.txt
@@ -234,11 +234,10 @@ test scenarios. For instance with a C program you may wish to test against
 both `clang` and `gcc`. In Python you may wish to test against multiple
 releases of cPython, or against different Python implementations, or both.
 
-Testr delegates the creation of such a test matrix to you, but will request a
-separate test environment for each *profile*. When test identifiers are
-supplied to testr on either the command line or listing files, they may be
-namespaced with a particular test profile. If they are not namespaced,
-they will be applied to all profiles.
+Testr delegates the creation of such a test matrix to you. When test
+identifiers are supplied to testr on either the command line or
+listing files, they may be namespaced with a particular test profile.
+If they are not namespaced, they will be applied to all profiles.
 
 Another common issue occurs with with parallel test running where test runners
 that use global resources such as well known ports, well known database names
@@ -249,7 +248,14 @@ containers or even separate machines. Such environments typically require
 some coordination when being used to run tests, so testr provides an explicit
 model for instantiating and disposing of such test environments. Testr does
 not differentiate between running commands in a regular subprocess, or via ssh
-to an arbitrary endpoint: they are all just test environments.
+to an arbitrary endpoint: they are all just test environments. Testr
+will request a separate test environment for each *profile* when
+environments are in use, allowing you to customise the context tests
+run within. If all your environments are homogenous then testr will
+currently overprovision environments when used with profiles. This can
+be worked around in your environment provisioning code. Future
+improvements will make profiles combined with isolated environments
+more flexible.
 
 The model testr has is intended to support both developers working
 incrementally on a change and CI systems running tests in a one-off setup,
@@ -268,8 +274,8 @@ The process testr follows is:
    testr gets an online scheduler, it will loop around the profiles one at a
    time.
 6. testr will then provision as many instances as needed to execute the tests.
-   The provisioning callout involves to synchronising source code and do any
-   other per-instance.
+   The provisioning callout is responsible for synchronising source
+   code and do any other per-instance preparation.
 7. testr will make callouts to execute tests, supplying files that should be
    copied into the execution environment. Note that instances may be used for
    more than one command execution.
@@ -291,9 +297,9 @@ For instance::
 
   list_profiles=echo py27 py34
   default_profiles=echo py27
-  instance_provision=foo -c $INSTANCE_COUNT $INSTANCE_PROFILE
-  instance_dispose=bar $INSTANCE_PROFILE $INSTANCE_IDS 
-  instance_execute=quux $INSTANCE_PROFILE $INSTANCE_ID $FILES -- $COMMAND
+  instance_provision=foo -c $INSTANCE_COUNT $PROFILE
+  instance_dispose=bar $PROFILE $INSTANCE_IDS 
+  instance_execute=quux $PROFILE $INSTANCE_ID $FILES -- $COMMAND
 
 These should operate as follows:
 
@@ -310,7 +316,7 @@ These should operate as follows:
   the value of default_profiles.
 
 * instance_provision should start up the number of instances provided in the
-  $INSTANCE_COUNT parameter suitable for running the $INSTANCE_PROFILE
+  $INSTANCE_COUNT parameter suitable for running the $PROFILE
   environment. It should print out on stdout the instance ids that testr
   should supply to the dispose and execute commands. These are scoped by
   testr to the profile (they may overlap those from a different profile).

--- a/doc/MANUAL.txt
+++ b/doc/MANUAL.txt
@@ -445,6 +445,14 @@ files (for a format 1 repository - the only current format):
   ``testr repo-config`` will dump a repo configration and
   ``test help repo-config`` has online help for all the repository settings.
 
+Stream requirements
+~~~~~~~~~~~~~~~~~~~
+
+This section is relevant for folk writing their own stream generators. Streams
+need to be Subunit V2 if the v2 module is available. Streams can include the
+same test multiple times, but if the same test is running concurrently they
+must be disambiguated via unique route codes.
+
 setuptools integration
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/MANUAL.txt
+++ b/doc/MANUAL.txt
@@ -235,7 +235,10 @@ both `clang` and `gcc`. In Python you may wish to test against multiple
 releases of cPython, or against different Python implementations, or both.
 
 Testr delegates the creation of such a test matrix to you, but will request a
-separate test environment for each *profile*.
+separate test environment for each *profile*. When test identifiers are
+supplied to testr on either the command line or listing files, they may be
+namespaced with a particular test profile. If they are not namespaced,
+they will be applied to all profiles.
 
 Another common issue occurs with with parallel test running where test runners
 that use global resources such as well known ports, well known database names

--- a/doc/MANUAL.txt
+++ b/doc/MANUAL.txt
@@ -297,7 +297,9 @@ These should operate as follows:
 * list_profiles should return profile names. Profile names are simple text
   with whitespace between them. list_profiles should return all the profiles
   available to the test run: missing profiles will cause errors when users
-  request them.
+  request them. If list_profiles is not configured, testr will instead use
+  a single profile "DEFAULT". If list_profiles is configured, but returns
+  nothing, testr will error.
 
 * default_profiles should also return profile names to run tests in. If it is
   not configured or returns an empty output, then all the profiles returned by

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pbr>=1.3
-fixtures
+fixtures>=1.3.1
 python-subunit >= 0.0.18
 six
 testtools >= 0.9.30

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pbr>=1.3
 fixtures
 python-subunit >= 0.0.18
+six
 testtools >= 0.9.30

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 pbr>=1.3
 fixtures>=1.3.1
 python-subunit >= 0.0.18
+shellvars
 six
 testtools >= 0.9.30

--- a/testrepository/_computecontext.py
+++ b/testrepository/_computecontext.py
@@ -48,7 +48,12 @@ class Cache:
         :param profile: The profile to allocate for.
         :return: An Instance.
         """
-        instance = self._available[profile].pop()
+        # Pick the same ones first consistently for two reasons.
+        # Firstly, deterministic testing is much nicer.
+        # Secondly, it means we re-use the same instance by preference which
+        # may add some block cache hits.
+        instance = sorted(self._available[profile])[0]
+        self._available[profile].remove(instance)
         self._allocated[profile].add(instance)
         return instance
 

--- a/testrepository/_computecontext.py
+++ b/testrepository/_computecontext.py
@@ -16,6 +16,7 @@
 
 __all__ = ['Cache', 'Instance']
 
+import functools
 from collections import defaultdict, namedtuple
 from itertools import chain
 
@@ -54,7 +55,7 @@ class Cache:
     def all(self):
         """Return an iterable of all instances."""
         instances = set()
-        return frozenset(reduce(
+        return frozenset(functools.reduce(
             lambda l, r: l.union(r),
             chain(self._available.values(), self._allocated.values()),
             set()))

--- a/testrepository/_computecontext.py
+++ b/testrepository/_computecontext.py
@@ -1,0 +1,68 @@
+#
+# Copyright (c) 2015 Testrepository Contributors
+#
+# Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
+# license at the users choice. A copy of both licenses are available in the
+# project source as Apache-2.0 and BSD. You may not use this file except in
+# compliance with one of these two licences.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# license you chose for the specific language governing permissions and
+# limitations under that license.
+
+"""Abstracts the idea of a place to run computations."""
+
+__all__ = ['Cache', 'Instance']
+
+from collections import namedtuple
+
+Instance = namedtuple('Instance', 'id')
+
+
+class Cache:
+    """A cache of instances."""
+
+    def __init__(self):
+        self._allocated = set()
+        self._available = set()
+
+    def add(self, instance):
+        """Add an instance to the cache."""
+        self._available.add(instance)
+
+    def allocate(self):
+        """Allocate an instance from available to allocated.
+        
+        :return: An Instance.
+        """
+        instance = self._available.pop()
+        self._allocated.add(instance)
+        return instance
+
+    def all(self):
+        """Return an iterable of all instances."""
+        return frozenset(self._allocated.union(self._available))
+
+    def release(self, instance):
+        """Return instance to the available pool.
+        
+        :param instance: An allocated instance.
+        """
+        self._allocated.remove(instance)
+        self._available.add(instance)
+
+    def remove(self, instance):
+        """Remove instance from the cache.
+        
+        :param instance: An allocated instance.
+        """
+        self._allocated.remove(instance)
+
+    def size(self):
+        """Return the number of instances in the cache.
+
+        This is the sum of the number of available and allocated instances.
+        """
+        return len(self._allocated) + len(self._available)

--- a/testrepository/_computecontext.py
+++ b/testrepository/_computecontext.py
@@ -20,7 +20,7 @@ from collections import namedtuple
 
 import six
 
-_Instance = namedtuple('Instance', 'id')
+_Instance = namedtuple('Instance', ['profile', 'id'])
 class Instance(_Instance):
 
     def __init__(self, *args):

--- a/testrepository/_computecontext.py
+++ b/testrepository/_computecontext.py
@@ -18,7 +18,15 @@ __all__ = ['Cache', 'Instance']
 
 from collections import namedtuple
 
-Instance = namedtuple('Instance', 'id')
+import six
+
+_Instance = namedtuple('Instance', 'id')
+class Instance(_Instance):
+
+    def __init__(self, *args):
+        for arg in args:
+            if arg is not None and type(arg) is not six.text_type:
+                raise ValueError('Bad argument %r' % (arg,))
 
 
 class Cache:

--- a/testrepository/commands/failing.py
+++ b/testrepository/commands/failing.py
@@ -68,7 +68,7 @@ class failing(Command):
                 else:
                     meta = tests[test_id]
                 test_profiles = profiles.intersection(test_dict['tags'])
-                meta['profiles'] = sorted(profile for profile in
+                meta['profiles'] = sorted(
                     test_profiles.union(meta['profiles']))
             analyzer = testtools.StreamToDict(on_test=capture)
             list_result = testtools.StreamSummary()

--- a/testrepository/commands/failing.py
+++ b/testrepository/commands/failing.py
@@ -44,6 +44,8 @@ class failing(Command):
         optparse.Option(
             "--list", action="store_true",
             default=False, help="Show only a list of failing tests."),
+        optparse.Option("--json", action="store_true",
+            default=False, help="Output list in JSON format."),
         ]
     # Can be assigned to to inject a custom command factory.
     command_factory = TestCommand
@@ -53,11 +55,25 @@ class failing(Command):
         self.ui.output_stream(stream)
         return 0
 
-    def _make_result(self, repo):
+    def _make_result(self, repo, tests):
         testcommand = self.command_factory(self.ui, repo)
-        if self.ui.options.list:
+        with testcommand:
+            profiles = testcommand.profiles
+        if self.ui.options.list or self.ui.options.json:
+            def capture(test_dict):
+                test_id = test_dict['id']
+                if test_id not in tests:
+                    meta = {'profiles': []}
+                    tests[test_id] = meta
+                else:
+                    meta = tests[test_id]
+                test_profiles = profiles.intersection(test_dict['tags'])
+                meta['profiles'] = sorted(profile for profile in
+                    test_profiles.union(meta['profiles']))
+            analyzer = testtools.StreamToDict(on_test=capture)
             list_result = testtools.StreamSummary()
-            return list_result, list_result
+            result = testtools.CopyStreamResult([analyzer, list_result])
+            return result, list_result
         else:
             return self.ui.make_result(repo.latest_id, testcommand)
 
@@ -68,7 +84,8 @@ class failing(Command):
             return self._show_subunit(run)
         case = run.get_test()
         failed = False
-        result, summary = self._make_result(repo)
+        tests = {}
+        result, summary = self._make_result(repo, tests)
         result.startTestRun()
         try:
             case.run(result)
@@ -79,8 +96,10 @@ class failing(Command):
             result = 1
         else:
             result = 0
-        if self.ui.options.list:
-            failing_tests = [
-                test for test, _ in summary.errors + summary.failures]
-            self.ui.output_tests(failing_tests)
+        if self.ui.options.list or self.ui.options.json:
+            if self.ui.options.json:
+                style = 'json'
+            else:
+                style = 'list'
+            self.ui.output_tests_meta(tests, style)
         return result

--- a/testrepository/commands/list_tests.py
+++ b/testrepository/commands/list_tests.py
@@ -15,6 +15,8 @@
 """List the tests from a project and show them."""
 
 from io import BytesIO
+import json
+import optparse
 
 from testtools import TestResult
 from testtools.compat import _b
@@ -32,6 +34,10 @@ class list_tests(Command):
 
     args = [StringArgument('testfilters', 0, None), DoubledashArgument(),
         StringArgument('testargs', 0, None)]
+    options = [
+        optparse.Option("--json", action="store_true",
+            default=False, help="Output list in JSON format."),
+        ]
     # Can be assigned to to inject a custom command factory.
     command_factory = TestCommand
 
@@ -53,10 +59,12 @@ class list_tests(Command):
                     ids = cmd.list_tests(testcommand.default_profiles)
                 else:
                     ids = cmd.test_ids
-                ids = strip_namespace(ids)
                 stream = BytesIO()
-                for id in ids:
-                    stream.write(('%s\n' % id).encode('utf8'))
+                if self.ui.options.json:
+                    json.dump(ids, stream, sort_keys=True)
+                else:
+                    for id in ids:
+                        stream.write(('%s\n' % id).encode('utf8'))
                 stream.seek(0)
                 self.ui.output_stream(stream)
                 return 0

--- a/testrepository/commands/list_tests.py
+++ b/testrepository/commands/list_tests.py
@@ -14,8 +14,6 @@
 
 """List the tests from a project and show them."""
 
-from io import BytesIO
-import json
 import optparse
 
 from testtools import TestResult
@@ -59,15 +57,11 @@ class list_tests(Command):
                     ids = cmd.list_tests(testcommand.default_profiles)
                 else:
                     ids = cmd.test_ids
-                stream = BytesIO()
                 if self.ui.options.json:
-                    stream.write(
-                        json.dumps(ids, sort_keys=True).encode('utf8'))
+                    style = 'json'
                 else:
-                    for id in sorted(ids):
-                        stream.write(('%s\n' % id).encode('utf8'))
-                stream.seek(0)
-                self.ui.output_stream(stream)
+                    style = 'list'
+                self.ui.output_tests_meta(ids, style)
                 return 0
             finally:
                 cmd.cleanUp()

--- a/testrepository/commands/list_tests.py
+++ b/testrepository/commands/list_tests.py
@@ -25,7 +25,7 @@ from testrepository.arguments.doubledash import DoubledashArgument
 from testrepository.arguments.string import StringArgument
 from testrepository.commands import Command
 from testrepository.testcommand import (
-    strip_namespace, testrconf_help, TestCommand)
+    testrconf_help, TestCommand)
 
 
 class list_tests(Command):
@@ -63,7 +63,7 @@ class list_tests(Command):
                 if self.ui.options.json:
                     json.dump(ids, stream, sort_keys=True)
                 else:
-                    for id in ids:
+                    for id in sorted(ids):
                         stream.write(('%s\n' % id).encode('utf8'))
                 stream.seek(0)
                 self.ui.output_stream(stream)

--- a/testrepository/commands/list_tests.py
+++ b/testrepository/commands/list_tests.py
@@ -22,7 +22,8 @@ from testtools.compat import _b
 from testrepository.arguments.doubledash import DoubledashArgument
 from testrepository.arguments.string import StringArgument
 from testrepository.commands import Command
-from testrepository.testcommand import testrconf_help, TestCommand
+from testrepository.testcommand import (
+    strip_namespace, testrconf_help, TestCommand)
 
 
 class list_tests(Command):
@@ -46,12 +47,13 @@ class list_tests(Command):
                 ids, self.ui.arguments['testargs'], test_filters=filters)
             cmd.setUp()
             try:
-                # Ugh.
+                # Ugh - poor layering. To Fix.
                 # List tests if the fixture has not already needed to to filter.
                 if filters is None:
-                    ids = cmd.list_tests()
+                    ids = cmd.list_tests(testcommand.default_profiles)
                 else:
                     ids = cmd.test_ids
+                ids = strip_namespace(ids)
                 stream = BytesIO()
                 for id in ids:
                     stream.write(('%s\n' % id).encode('utf8'))

--- a/testrepository/commands/list_tests.py
+++ b/testrepository/commands/list_tests.py
@@ -61,7 +61,8 @@ class list_tests(Command):
                     ids = cmd.test_ids
                 stream = BytesIO()
                 if self.ui.options.json:
-                    json.dump(ids, stream, sort_keys=True)
+                    stream.write(
+                        json.dumps(ids, sort_keys=True).encode('utf8'))
                 else:
                     for id in sorted(ids):
                         stream.write(('%s\n' % id).encode('utf8'))

--- a/testrepository/commands/load.py
+++ b/testrepository/commands/load.py
@@ -75,7 +75,7 @@ class load(Command):
         optparse.Option("--full-results", action="store_true",
             default=False,
             help="No-op - deprecated and kept only for backwards compat."),
-        optparse.Option("--profiles",
+        optparse.Option("-p", "--profiles",
             help="Comma separated list of profiles that may be present in the "
                  "stream. By default the list_profiles hook in testr.conf is "
                  "queried.",

--- a/testrepository/commands/load.py
+++ b/testrepository/commands/load.py
@@ -75,6 +75,11 @@ class load(Command):
         optparse.Option("--full-results", action="store_true",
             default=False,
             help="No-op - deprecated and kept only for backwards compat."),
+        optparse.Option("--profiles",
+            help="Comma separated list of profiles that may be present in the "
+                 "stream. By default the list_profiles hook in testr.conf is "
+                 "queried.",
+            default=""),
         ]
     # Can be assigned to to inject a custom command factory.
     command_factory = TestCommand
@@ -88,7 +93,10 @@ class load(Command):
                 repo = self.repository_factory.initialise(path)
             else:
                 raise
-        testcommand = self.command_factory(self.ui, repo)
+        profiles = self.ui.options.profiles.split(',')
+        if profiles == ['']:
+            profiles = None
+        testcommand = self.command_factory(self.ui, repo, profiles=profiles)
         # Not a full implementation of TestCase, but we only need to iterate
         # back to it. Needs to be a callable - its a head fake for
         # testsuite.add.
@@ -126,35 +134,38 @@ class load(Command):
                 decorate = partial(mktagger, pos)
                 case = testtools.DecorateTestCaseResult(case, decorate)
                 yield (case, str(pos))
-        case = testtools.ConcurrentStreamTestSuite(make_tests)
-        # One unmodified copy of the stream to repository storage
-        inserter = repo.get_inserter(partial=self.ui.options.partial)
-        # One copy of the stream to the UI layer after performing global
-        # filters.
-        try:
-            previous_run = repo.get_latest_run()
-        except KeyError:
-            previous_run = None
-        output_result, summary_result = self.ui.make_result(
-            inserter.get_id, testcommand, previous_run=previous_run)
-        result = testtools.CopyStreamResult([inserter, output_result])
-        runner_thread = None
-        result.startTestRun()
-        try:
-            # Convert user input into a stdin event stream
-            interactive_streams = list(self.ui.iter_streams('interactive'))
-            if interactive_streams:
-                case = InputToStreamResult(interactive_streams[0])
-                runner_thread = threading.Thread(
-                    target=case.run, args=(result,))
-                runner_thread.daemon = True
-                runner_thread.start()
-            case.run(result)
-        finally:
-            result.stopTestRun()
-            if interactive_streams and runner_thread:
-                runner_thread.stop = True
-                runner_thread.join(10)
+        # Setup testcommand to query profiles etc.
+        with testcommand:
+            case = testtools.ConcurrentStreamTestSuite(make_tests)
+            # One unmodified copy of the stream to repository storage
+            inserter = repo.get_inserter(
+                partial=self.ui.options.partial, profiles=testcommand.profiles)
+            # One copy of the stream to the UI layer after performing global
+            # filters.
+            try:
+                previous_run = repo.get_latest_run()
+            except KeyError:
+                previous_run = None
+            output_result, summary_result = self.ui.make_result(
+                inserter.get_id, testcommand, previous_run=previous_run)
+            result = testtools.CopyStreamResult([inserter, output_result])
+            runner_thread = None
+            result.startTestRun()
+            try:
+                # Convert user input into a stdin event stream
+                interactive_streams = list(self.ui.iter_streams('interactive'))
+                if interactive_streams:
+                    case = InputToStreamResult(interactive_streams[0])
+                    runner_thread = threading.Thread(
+                        target=case.run, args=(result,))
+                    runner_thread.daemon = True
+                    runner_thread.start()
+                case.run(result)
+            finally:
+                result.stopTestRun()
+                if interactive_streams and runner_thread:
+                    runner_thread.stop = True
+                    runner_thread.join(10)
         if not summary_result.wasSuccessful():
             return 1
         else:

--- a/testrepository/commands/run.py
+++ b/testrepository/commands/run.py
@@ -345,7 +345,10 @@ class run(Command):
         cmd.setUp()
         try:
             def run_tests():
-                run_procs = [('subunit', ReturnCodeToSubunit(proc)) for proc in cmd.run_tests()]
+                run_procs = []
+                for proc in cmd.run_tests():
+                    stream = ReturnCodeToSubunit(proc.run_proc)
+                    run_procs.append(('subunit', stream))
                 options = {}
                 if (self.ui.options.failing or self.ui.options.analyze_isolation
                     or self.ui.options.isolated):

--- a/testrepository/commands/run.py
+++ b/testrepository/commands/run.py
@@ -164,7 +164,15 @@ class run(Command):
             if test_dict['status'] == 'fail':
                 test_profiles = test_dict['tags'].intersection(
                     profiles)
-                ids[test_dict['id']] = {'profiles': sorted(test_profiles)}
+                test_id = test_dict['id']
+                if test_id not in ids:
+                    meta = {'profiles': []}
+                    ids[test_id] = meta
+                else:
+                    meta = ids[test_id]
+                test_profiles = profiles.intersection(test_dict['tags'])
+                meta['profiles'] = sorted(
+                    test_profiles.union(meta['profiles']))
         result = testtools.StreamToDict(gather_errors)
         result.startTestRun()
         try:
@@ -365,7 +373,7 @@ class run(Command):
                 for proc in cmd.run_tests():
                     stream = ReturnCodeToSubunit(proc.run_proc)
                     run_procs.append(('subunit', stream))
-                options = {'profiles': ','.join(profiles)}
+                options = {'profiles': ','.join(sorted(profiles))}
                 if (self.ui.options.failing or self.ui.options.analyze_isolation
                     or self.ui.options.isolated):
                     options['partial'] = True

--- a/testrepository/commands/run.py
+++ b/testrepository/commands/run.py
@@ -159,10 +159,11 @@ class run(Command):
     def _find_failing(self, repo):
         run = repo.get_failing()
         case = run.get_test()
-        ids = []
+        ids = {}
         def gather_errors(test_dict):
             if test_dict['status'] == 'fail':
-                ids.append(test_dict['id'])
+                # XX: todo handling of profiles.
+                ids[test_dict['id']] = {'profiles': ['DEFAULT']}
         result = testtools.StreamToDict(gather_errors)
         result.startTestRun()
         try:
@@ -197,7 +198,11 @@ class run(Command):
                 else:
                     # We have some already limited set of ids, just reduce to ids
                     # that are both failing and listed.
-                    ids = list_ids.intersection(ids)
+                    _ids = {}
+                    for test in ids:
+                        if test in list_ids:
+                            _ids[test] = list_ids[test]
+                    ids = _ids
             if not self.ui.options.analyze_isolation:
                 cmd = testcommand.get_run_command(ids, self.ui.arguments['testargs'],
                     test_filters = filters)

--- a/testrepository/commands/run.py
+++ b/testrepository/commands/run.py
@@ -365,7 +365,7 @@ class run(Command):
                 for proc in cmd.run_tests():
                     stream = ReturnCodeToSubunit(proc.run_proc)
                     run_procs.append(('subunit', stream))
-                options = {'profiles': ' '.join(profiles)}
+                options = {'profiles': ','.join(profiles)}
                 if (self.ui.options.failing or self.ui.options.analyze_isolation
                     or self.ui.options.isolated):
                     options['partial'] = True

--- a/testrepository/testcommand.py
+++ b/testrepository/testcommand.py
@@ -164,6 +164,22 @@ def _callout_concurrency(parser, ui):
     return int(out.strip())
 
 
+def _default_profiles(parser, ui):
+    """Callout to determine profiles to use by default."""
+    out = _callout('default_profiles', parser, ui)
+    if out is None:
+        return set()
+    return set([s for s in out.split() if s])
+
+
+def _list_profiles(parser, ui):
+    """Callout to determine available profiles."""
+    out = _callout('list_profiles', parser, ui)
+    if out is None:
+        return set()
+    return set([s for s in out.split() if s])
+
+
 def local_concurrency():
     try:
         return multiprocessing.cpu_count()
@@ -520,20 +536,6 @@ class TestListingFixture(Fixture):
         for partition, group_id in zip(itertools.cycle(partitions), unknown):
             partition.extend(group_ids[group_id])
         return partitions
-
-    def default_profiles(self):
-        """Callout to determine profiles to use by default."""
-        out = _callout('default_profiles', self._parser, self.ui)
-        if out is None:
-            return set()
-        return set([s for s in out.split() if s])
-
-    def list_profiles(self):
-        """Callout to determine available profiles."""
-        out = _callout('list_profiles', self._parser, self.ui)
-        if out is None:
-            return set()
-        return set([s for s in out.split() if s])
 
 
 class TestCommand(Fixture):

--- a/testrepository/testcommand.py
+++ b/testrepository/testcommand.py
@@ -690,18 +690,21 @@ class TestCommand(Fixture):
     run_factory = TestListingFixture
     oldschool = False
 
-    def __init__(self, ui, repository):
+    def __init__(self, ui, repository, profiles=None):
         """Create a TestCommand.
 
         :param ui: A testrepository.ui.UI object which is used to obtain the
             location of the .testr.conf.
         :param repository: A testrepository.repository.Repository used for
             determining test times when partitioning tests.
+        :param profiles: If supplied, override the detection of profiles from
+            .testr.conf.
         """
         super(TestCommand, self).__init__()
         self.ui = ui
         self.repository = repository
         self._instance_cache = None
+        self._profiles = profiles
 
     def setUp(self):
         super(TestCommand, self).setUp()
@@ -720,7 +723,8 @@ class TestCommand(Fixture):
                 self.concurrency = local_concurrency()
             if not self.concurrency:
                 self.concurrency = 1
-        self.profiles = _list_profiles(self.get_parser(), self.ui)
+        self.profiles = (
+            self._profiles or _list_profiles(self.get_parser(), self.ui))
         self.default_profiles = _default_profiles(self.get_parser(), self.ui)
         if not self.profiles:
             # Default configuration

--- a/testrepository/testcommand.py
+++ b/testrepository/testcommand.py
@@ -229,6 +229,7 @@ class TestListingFixture(Fixture):
         self._parser = parser
         self.test_filters = test_filters
         self._group_callback = group_callback
+        assert instance_source is not None
         self._instance_source = instance_source
         assert concurrency is not None
         self.concurrency = concurrency
@@ -349,8 +350,6 @@ class TestListingFixture(Fixture):
         :param concurrency: The number of instances to ask for (used to avoid
             death-by-1000 cuts of latency.
         """
-        if self._instance_source is None:
-            return None, cmd
         instance = self._instance_source.obtain_instance()
         if instance is not None:
             try:

--- a/testrepository/testcommand.py
+++ b/testrepository/testcommand.py
@@ -514,14 +514,20 @@ class TestListingFixture(Fixture):
         """List the tests returned by list_cmd in profiles.
 
         :param profiles: The profiles to query.
-        :return: A list of test ids.
+        :return: A dict of testname:testmetadata dicts. Current metadata keys
+            are 'profiles'. e.g. {'test': {'profiles': ['p1']}}
         """
         if '$LISTOPT' not in self.template:
             raise ValueError("LISTOPT not configured in .testr.conf")
         result = {}
         for profile in profiles:
             ids = self._list_tests(profile)
-            result[profile] = ids
+            for test_id in ids:
+                meta = result.get(test_id)
+                if meta is None:
+                    meta = {'profiles': []}
+                    result[test_id] = meta
+                meta['profiles'].append(profile)
         return result
 
     def _list_tests(self, profile):

--- a/testrepository/testcommand.py
+++ b/testrepository/testcommand.py
@@ -633,6 +633,7 @@ class TestCommand(Fixture):
         Note this is not threadsafe: calling it from multiple threads would
         likely result in shared results.
         """
+        profile = u"DEFAULT"
         while self._instance_cache.size() < concurrency:
             try:
                 cmd = self.get_parser().get('DEFAULT', 'instance_provision')
@@ -650,11 +651,10 @@ class TestCommand(Fixture):
                 raise ValueError('Provisioning instances failed, return %d' %
                     proc.returncode)
             out = out.decode('utf-8')
-            profile = u"DEFAULT"
             new_instances = set([Instance(profile, item.strip()) for item in out.split()])
             list(map(self._instance_cache.add, new_instances))
         # We only ask for instances when one should be available.
-        return self._instance_cache.allocate()
+        return self._instance_cache.allocate(profile)
 
     def release_instance(self, instance):
         """Return instance_ids to the pool for reuse."""

--- a/testrepository/testcommand.py
+++ b/testrepository/testcommand.py
@@ -21,6 +21,7 @@ from extras import (
 
 from collections import defaultdict
 ConfigParser = try_imports(['ConfigParser', 'configparser'])
+from functools import partial
 import io
 import itertools
 import operator
@@ -606,15 +607,13 @@ class TestCommand(Fixture):
             group_callback = None
         if self.oldschool:
             listpath = os.path.join(self.ui.here, 'failing.list')
-            result = self.run_factory(test_ids, cmd, listopt, idoption,
-                self.ui, self.repository, listpath=listpath, parser=parser,
-                test_filters=test_filters, instance_source=self,
-                group_callback=group_callback)
+            run_factory = partial(self.run_factory, listpath=listpath)
         else:
-            result = self.run_factory(test_ids, cmd, listopt, idoption,
-                self.ui, self.repository, parser=parser,
-                test_filters=test_filters, instance_source=self,
-                group_callback=group_callback)
+            run_factory = self.run_factory
+        result = run_factory(test_ids, cmd, listopt, idoption,
+            self.ui, self.repository, parser=parser,
+            test_filters=test_filters, instance_source=self,
+            group_callback=group_callback)
         return result
 
     def get_filter_tags(self):

--- a/testrepository/testcommand.py
+++ b/testrepository/testcommand.py
@@ -473,6 +473,13 @@ class TestListingFixture(Fixture):
             # No concurrency logic known.
             return None
 
+    def default_profiles(self):
+        """Callout to determine profiles to use by default."""
+        out = self._callout('default_profiles')
+        if out is None:
+            return set()
+        return set([s for s in out.split() if s])
+
     def list_profiles(self):
         """Callout to determine available profiles."""
         out = self._callout('list_profiles')

--- a/testrepository/testcommand.py
+++ b/testrepository/testcommand.py
@@ -650,7 +650,8 @@ class TestCommand(Fixture):
                 raise ValueError('Provisioning instances failed, return %d' %
                     proc.returncode)
             out = out.decode('utf-8')
-            new_instances = set([Instance(item.strip()) for item in out.split()])
+            profile = u"DEFAULT"
+            new_instances = set([Instance(profile, item.strip()) for item in out.split()])
             list(map(self._instance_cache.add, new_instances))
         # We only ask for instances when one should be available.
         return self._instance_cache.allocate()

--- a/testrepository/testcommand.py
+++ b/testrepository/testcommand.py
@@ -525,7 +525,7 @@ class TestListingFixture(Fixture):
         if '$LISTOPT' not in self.template:
             raise ValueError("LISTOPT not configured in .testr.conf")
         result = {}
-        for profile in profiles:
+        for profile in sorted(profiles):
             ids = self._list_tests(profile)
             for test_id in ids:
                 meta = result.get(test_id)
@@ -575,7 +575,7 @@ class TestListingFixture(Fixture):
         :return: A list of spawned processes.
         """
         result = []
-        for profile in self._instance_source.default_profiles:
+        for profile in sorted(self._instance_source.default_profiles):
             if self.test_ids is not None:
                 profile_tests = _profile_tests(self.test_ids, profile)
             else:

--- a/testrepository/testcommand.py
+++ b/testrepository/testcommand.py
@@ -334,7 +334,7 @@ class TestListingFixture(Fixture):
                 instance_prefix = self._parser.get(
                     'DEFAULT', 'instance_execute')
                 variables = {
-                    'INSTANCE_ID': instance.id.decode('utf8'),
+                    'INSTANCE_ID': instance.id,
                     'COMMAND': cmd,
                     # --list-tests cannot use FILES, so handle it being unset.
                     'FILES': getattr(self, 'list_file_name', None) or '',
@@ -540,7 +540,7 @@ class TestCommand(Fixture):
         instances = cache.all()
         dispose_cmd = re.sub(
             variable_regex,
-            ' '.join(sorted(instance.id.decode('utf') for instance in instances)),
+            ' '.join(sorted(instance.id for instance in instances)),
             dispose_cmd)
         self.ui.output_values([('running', dispose_cmd)])
         run_proc = self.ui.subprocess_Popen(dispose_cmd, shell=True)
@@ -649,6 +649,7 @@ class TestCommand(Fixture):
             if proc.returncode:
                 raise ValueError('Provisioning instances failed, return %d' %
                     proc.returncode)
+            out = out.decode('utf-8')
             new_instances = set([Instance(item.strip()) for item in out.split()])
             list(map(self._instance_cache.add, new_instances))
         # We only ask for instances when one should be available.

--- a/testrepository/testcommand.py
+++ b/testrepository/testcommand.py
@@ -150,7 +150,7 @@ def apply_profiles(profiles, test_ids):
     for test_id in test_ids:
         meta = {'profiles': []}
         result[test_id] = meta
-        meta['profiles'] = list(profiles)
+        meta['profiles'] = sorted(profiles)
     return result
 
 

--- a/testrepository/tests/commands/test_commands.py
+++ b/testrepository/tests/commands/test_commands.py
@@ -31,7 +31,8 @@ class TestCommandCommands(ResourcedTestCase):
         ui, cmd = self.get_test_ui_and_cmd()
         cmd.execute()
         self.assertEqual(1, len(ui.outputs))
-        self.assertEqual('table', ui.outputs[0][0])
+        self.assertEqual(
+            'table', ui.outputs[0][0], 'outputs: %r' % (ui.outputs,))
         self.assertEqual(('command', 'description'), ui.outputs[0][1][0])
         command_names = [row[0] for row in ui.outputs[0][1]]
         summaries = [row[1] for row in ui.outputs[0][1]]

--- a/testrepository/tests/commands/test_list_tests.py
+++ b/testrepository/tests/commands/test_list_tests.py
@@ -98,7 +98,10 @@ class TestCommand(ResourcedTestCase):
             ('popen', (expected_cmd,),
              {'shell': True, 'stdout': PIPE, 'stdin': PIPE}),
             ('communicate',),
-            ('stream', _b('returned\nvalues\n')),
+            ('tests_meta',
+              {'returned': {'profiles': ['DEFAULT']},
+               'values': {'profiles': ['DEFAULT']}},
+              'list'),
             ], ui.outputs)
 
     def test_filters_use_filtered_list(self):
@@ -126,7 +129,7 @@ class TestCommand(ResourcedTestCase):
             ('popen', (expected_cmd,),
              {'shell': True, 'stdout': PIPE, 'stdin': PIPE}),
             ('communicate',),
-            ('stream', _b('returned\n')),
+            ('tests_meta', {'returned': {'profiles': ['DEFAULT']}}, 'list')
             ], ui.outputs)
         self.assertEqual(0, retcode)
 
@@ -161,7 +164,7 @@ class TestCommand(ResourcedTestCase):
             'return': {'profiles': ['p1']},
             'values': {'profiles': ['p2']},
             }
-        expected_bytes = json.dumps(expected_as_dict, sort_keys=True)
+        expected_bytes = json.dumps(expected_as_dict, sort_keys=True).encode('utf8')
         self.assertEqual([
             ('popen', ('list_profiles',), {'shell': True, 'stdin': -1, 'stdout': -1}),
             ('communicate',),
@@ -171,6 +174,7 @@ class TestCommand(ResourcedTestCase):
             ('values', [('running', _u('foo --list  p1'))]),
             ('popen', (_u('foo --list  p1'),), {'shell': True, 'stdin': -1, 'stdout': -1}),
             ('communicate',),
-            ('stream', expected_bytes),
+            ('tests_meta',
+             {'return': {'profiles': ['p1']}, 'values': {'profiles': ['p2']}}, 'json'),
             ], ui.outputs)
         self.assertEqual(0, retcode)

--- a/testrepository/tests/commands/test_list_tests.py
+++ b/testrepository/tests/commands/test_list_tests.py
@@ -23,7 +23,7 @@ import textwrap
 from extras import try_import
 import subunit
 v2_avail = try_import('subunit.ByteStreamToStreamResult')
-from testtools.compat import _b
+from testtools.compat import _b, _u
 from testtools.matchers import MatchesException
 
 from testrepository.commands import list_tests

--- a/testrepository/tests/commands/test_load.py
+++ b/testrepository/tests/commands/test_load.py
@@ -16,7 +16,9 @@
 
 from datetime import datetime, timedelta
 from io import BytesIO
+import os.path
 from tempfile import NamedTemporaryFile
+import textwrap
 
 from extras import try_import
 v2_avail = try_import('subunit.ByteStreamToStreamResult')
@@ -36,12 +38,27 @@ from testrepository.tests import (
     StubTestCommand,
     Wildcard,
     )
+from testrepository.tests.stubpackage import TempDirResource
 from testrepository.tests.test_repository import RecordingRepositoryFactory
 from testrepository.tests.repository.test_file import HomeDirTempDir
 from testrepository.repository import memory, RepositoryNotFound
 
 
 class TestCommandLoad(ResourcedTestCase):
+
+    resources = [('tempdir', TempDirResource())]
+
+    def dirty(self):
+        # Ugly: TODO - improve testresources to make this go away.
+        dict(self.resources)['tempdir']._dirty = True
+
+    def config_path(self):
+        return os.path.join(self.tempdir, '.testr.conf')
+
+    def set_config(self, text):
+        self.dirty()
+        with open(self.config_path(), 'wt') as stream:
+            stream.write(text)
 
     def test_load_loads_subunit_stream_to_default_repository(self):
         ui = UI([('subunit', _b(''))])
@@ -80,6 +97,38 @@ class TestCommandLoad(ResourcedTestCase):
         self.assertTrue('subunit' in ui.input_streams)
         # Results loaded
         self.assertEqual(1, repo.count())
+
+    def test_load_implicit_profiles(self):
+        # load should query profiles from TestCommand if none are supplied.
+        # Detect this by failing a test in a memory repo.
+        if v2_avail:
+            buffer = BytesIO()
+            stream = subunit.StreamResultToBytes(buffer)
+            stream.status(
+                test_id='foo', test_status='fail', test_tags=set(['p1']))
+            stream.status(
+                test_id='foo', test_status='fail', test_tags=set(['p2']))
+            subunit_bytes = buffer.getvalue()
+        else:
+            self.skip('no v1 test')
+        ui = UI([('subunit', subunit_bytes)])
+        ui.proc_outputs=[_b('p1 p2')]
+        ui.here = self.tempdir
+        self.set_config(textwrap.dedent("""\
+            [DEFAULT]
+            list_profiles=list_profiles
+            """))
+        cmd = load.load(ui)
+        ui.set_command(cmd)
+        cmd.repository_factory = memory.RepositoryFactory()
+        cmd.repository_factory.initialise(ui.here)
+        self.assertEqual(1, cmd.execute())
+        self.assertEqual([
+            ('popen', ('list_profiles',), {'shell': True, 'stdin': -1, 'stdout': -1}),
+            ('communicate',),
+            ('results', Wildcard),
+            ('summary', False, 2, None, Wildcard, None, [('id', 0, None), ('failures', 2, None)]),
+            ], ui.outputs)
 
     def test_load_initialises_repo_if_doesnt_exist_and_init_forced(self):
         ui = UI([('subunit', _b(''))], options=[('force_init', True)])

--- a/testrepository/tests/commands/test_load.py
+++ b/testrepository/tests/commands/test_load.py
@@ -311,10 +311,7 @@ class TestCommandLoad(ResourcedTestCase):
         ui.set_command(cmd)
         cmd.repository_factory = memory.RepositoryFactory()
         repo = cmd.repository_factory.initialise(ui.here)
-        # XXX: Circumvent the AutoTimingTestResultDecorator so we can get
-        # predictable times, rather than ones based on the system
-        # clock. (Would normally expect to use repo.get_inserter())
-        inserter = repo._get_inserter(False)
+        inserter = repo.get_inserter(False)
         # Insert a run with different results.
         inserter.startTestRun()
         inserter.status(test_id=self.id(), test_status='inprogress',

--- a/testrepository/tests/commands/test_run.py
+++ b/testrepository/tests/commands/test_run.py
@@ -78,14 +78,15 @@ class BaseTestCommand(ResourcedTestCase):
         inserter = repo.get_inserter()
         inserter.startTestRun()
         inserter.status(
-            test_id='passing', test_status='success', test_tags=['DEFAULT'])
+            test_id='passing', test_status='success',
+            test_tags=set(['DEFAULT']))
         if failures:
             inserter.status(
                 test_id='failing1', test_status='fail',
-                test_tags=['DEFAULT', 'p1'])
+                test_tags=set(['DEFAULT', 'p1']))
             inserter.status(
                 test_id='failing2', test_status='fail',
-                test_tags=['DEFAULT', 'p2'])
+                test_tags=set(['DEFAULT', 'p2']))
         inserter.stopTestRun()
 
     def capture_ids(self, list_result=None):

--- a/testrepository/tests/test__compute_context.py
+++ b/testrepository/tests/test__compute_context.py
@@ -52,11 +52,11 @@ class TestCache(ResourcedTestCase):
         self.assertRaises(KeyError, cache.remove, instance)
         self.assertIs(instance, cache.allocate('profile'))
         cache.release(instance)
-        self.assertEqual(1, cache.size())
+        self.assertEqual(1, cache.size('profile'))
         self.assertIs(instance, cache.allocate('profile'))
-        self.assertEqual(1, cache.size())
+        self.assertEqual(1, cache.size('profile'))
         cache.remove(instance)
-        self.assertEqual(0, cache.size())
+        self.assertEqual(0, cache.size('profile'))
         self.assertRaises(KeyError, cache.remove, instance)
 
     def test_all(self):
@@ -87,7 +87,8 @@ class TestCache(ResourcedTestCase):
         cache.add(instance4)
         cache.allocate('p1')
         cache.allocate('p2')
-        self.assertEqual(4, cache.size())
+        self.assertEqual(2, cache.size('p1'))
+        self.assertEqual(2, cache.size('p2'))
 
     def test_allocate_empty(self):
         self.assertRaises(KeyError, Cache().allocate, 'p1')

--- a/testrepository/tests/test__compute_context.py
+++ b/testrepository/tests/test__compute_context.py
@@ -1,0 +1,65 @@
+#
+# Copyright (c) 2015 Testrepository Contributors
+#
+# Licensed under either the Apache License, Version 2.0 or the BSD 3-clause
+# license at the users choice. A copy of both licenses are available in the
+# project source as Apache-2.0 and BSD. You may not use this file except in
+# compliance with one of these two licences.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under these licenses is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# license you chose for the specific language governing permissions and
+# limitations under that license.
+
+"""Tests for the _computecontext module."""
+
+from testrepository._computecontext import (
+    Cache,
+    Instance,
+    )
+from testrepository.tests import ResourcedTestCase
+
+class TestInstance(ResourcedTestCase):
+
+    def test_fields(self):
+        instance = Instance('1')
+        self.assertEqual('1', instance.id)
+
+    def test_in_set(self):
+        instances = set()
+        instances.add(Instance('2'))
+
+
+class TestCache(ResourcedTestCase):
+
+    def test_create(self):
+        cache = Cache()
+        self.assertNotEqual(cache, None)
+
+    def test_smoke(self):
+        cache = Cache()
+        instance = Instance('1')
+        cache.add(instance)
+        # Can't remove unallocated instances.
+        self.assertRaises(KeyError, cache.remove, instance)
+        self.assertIs(instance, cache.allocate())
+        cache.release(instance)
+        self.assertEqual(1, cache.size())
+        self.assertIs(instance, cache.allocate())
+        self.assertEqual(1, cache.size())
+        cache.remove(instance)
+        self.assertEqual(0, cache.size())
+        self.assertRaises(KeyError, cache.remove, instance)
+
+    def test_all(self):
+        cache = Cache()
+        instance1 = Instance('1')
+        instance2 = Instance('2')
+        cache.add(instance1)
+        cache.add(instance2)
+        cache.allocate()
+        self.assertEqual(2, cache.size())
+
+    def test_allocat_empty(self):
+        self.assertRaises(KeyError, Cache().allocate)

--- a/testrepository/tests/test__compute_context.py
+++ b/testrepository/tests/test__compute_context.py
@@ -25,15 +25,17 @@ from testrepository.tests import ResourcedTestCase
 class TestInstance(ResourcedTestCase):
 
     def test_fields(self):
-        instance = Instance('1')
+        instance = Instance('profile', '1')
+        self.assertEqual('profile', instance.profile)
         self.assertEqual('1', instance.id)
 
-    def test_in_set(self):
+    def test_can_be_put_in_set(self):
         instances = set()
-        instances.add(Instance('2'))
+        instances.add(Instance('profile', '2'))
 
     def test_rejects_bytes(self):
-        self.assertRaises(ValueError, Instance, b'1')
+        self.assertRaises(ValueError, Instance, 'profile', b'1')
+        self.assertRaises(ValueError, Instance, b'profile', '1')
 
 
 class TestCache(ResourcedTestCase):
@@ -44,7 +46,7 @@ class TestCache(ResourcedTestCase):
 
     def test_smoke(self):
         cache = Cache()
-        instance = Instance('1')
+        instance = Instance('profile', '1')
         cache.add(instance)
         # Can't remove unallocated instances.
         self.assertRaises(KeyError, cache.remove, instance)
@@ -59,8 +61,8 @@ class TestCache(ResourcedTestCase):
 
     def test_all(self):
         cache = Cache()
-        instance1 = Instance('1')
-        instance2 = Instance('2')
+        instance1 = Instance('profile', '1')
+        instance2 = Instance('profile', '2')
         cache.add(instance1)
         cache.add(instance2)
         cache.allocate()

--- a/testrepository/tests/test__compute_context.py
+++ b/testrepository/tests/test__compute_context.py
@@ -50,10 +50,10 @@ class TestCache(ResourcedTestCase):
         cache.add(instance)
         # Can't remove unallocated instances.
         self.assertRaises(KeyError, cache.remove, instance)
-        self.assertIs(instance, cache.allocate())
+        self.assertIs(instance, cache.allocate('profile'))
         cache.release(instance)
         self.assertEqual(1, cache.size())
-        self.assertIs(instance, cache.allocate())
+        self.assertIs(instance, cache.allocate('profile'))
         self.assertEqual(1, cache.size())
         cache.remove(instance)
         self.assertEqual(0, cache.size())
@@ -61,12 +61,38 @@ class TestCache(ResourcedTestCase):
 
     def test_all(self):
         cache = Cache()
-        instance1 = Instance('profile', '1')
-        instance2 = Instance('profile', '2')
+        instance1 = Instance('p1', '1')
+        instance2 = Instance('p2', '2')
+        instance3 = Instance('p1', '3')
+        instance4 = Instance('p2', '4')
         cache.add(instance1)
         cache.add(instance2)
-        cache.allocate()
-        self.assertEqual(2, cache.size())
+        cache.add(instance3)
+        cache.add(instance4)
+        cache.allocate('p1')
+        cache.allocate('p2')
+        self.assertEqual(
+            frozenset([instance1, instance2, instance3, instance4]),
+            cache.all())
 
-    def test_allocat_empty(self):
-        self.assertRaises(KeyError, Cache().allocate)
+    def test_size(self):
+        cache = Cache()
+        instance1 = Instance('p1', '1')
+        instance2 = Instance('p2', '2')
+        instance3 = Instance('p1', '3')
+        instance4 = Instance('p2', '4')
+        cache.add(instance1)
+        cache.add(instance2)
+        cache.add(instance3)
+        cache.add(instance4)
+        cache.allocate('p1')
+        cache.allocate('p2')
+        self.assertEqual(4, cache.size())
+
+    def test_allocate_empty(self):
+        self.assertRaises(KeyError, Cache().allocate, 'p1')
+
+    def test_allocate_profile_empty(self):
+        c = Cache()
+        c.add(Instance('p1', '1'))
+        self.assertRaises(KeyError, c.allocate, 'p2')

--- a/testrepository/tests/test__compute_context.py
+++ b/testrepository/tests/test__compute_context.py
@@ -91,9 +91,9 @@ class TestCache(ResourcedTestCase):
         self.assertEqual(2, cache.size('p2'))
 
     def test_allocate_empty(self):
-        self.assertRaises(KeyError, Cache().allocate, 'p1')
+        self.assertRaises(Exception, Cache().allocate, 'p1')
 
     def test_allocate_profile_empty(self):
         c = Cache()
         c.add(Instance('p1', '1'))
-        self.assertRaises(KeyError, c.allocate, 'p2')
+        self.assertRaises(Exception, c.allocate, 'p2')

--- a/testrepository/tests/test__compute_context.py
+++ b/testrepository/tests/test__compute_context.py
@@ -14,6 +14,8 @@
 
 """Tests for the _computecontext module."""
 
+from __future__ import unicode_literals
+
 from testrepository._computecontext import (
     Cache,
     Instance,
@@ -29,6 +31,9 @@ class TestInstance(ResourcedTestCase):
     def test_in_set(self):
         instances = set()
         instances.add(Instance('2'))
+
+    def test_rejects_bytes(self):
+        self.assertRaises(ValueError, Instance, b'1')
 
 
 class TestCache(ResourcedTestCase):

--- a/testrepository/tests/test_repository.py
+++ b/testrepository/tests/test_repository.py
@@ -164,6 +164,18 @@ class TestRepositoryContract(ResourcedTestCase):
             analyzer.stopTestRun()
         return analyzer
 
+    def get_failing_list(self, repo):
+        """Analyze a failing stream from repo and return test dicts for it."""
+        run = repo.get_failing()
+        analyzed = []
+        analyzer = testtools.StreamToDict(on_test=analyzed.append)
+        analyzer.startTestRun()
+        try:
+            run.get_test().run(analyzer)
+        finally:
+            analyzer.stopTestRun()
+        return analyzed
+
     def get_last_run(self, repo):
         """Return the results from a stream."""
         run = repo.get_test_run(repo.latest_id())
@@ -179,9 +191,14 @@ class TestRepositoryContract(ResourcedTestCase):
         repo = self.repo_impl.initialise(self.sample_url)
         self.assertIsInstance(repo, repository.AbstractRepository)
 
-    def test_can_get_inserter(self):
+    def test_can_get_inserter_no_args(self):
         repo = self.repo_impl.initialise(self.sample_url)
         result = repo.get_inserter()
+        self.assertNotEqual(None, result)
+
+    def test_can_get_inserter_profiles(self):
+        repo = self.repo_impl.initialise(self.sample_url)
+        result = repo.get_inserter(profiles=['DEFAULT'])
         self.assertNotEqual(None, result)
 
     def test_insert_stream_smoke(self):
@@ -556,3 +573,165 @@ class TestRepositoryContract(ResourcedTestCase):
         self.assertEqual(run_id, repo.latest_id())
         returned_ids = repo.get_test_ids(run_id)
         self.assertEqual([test.id() for test in test_cases], returned_ids)
+
+    def test_insert_multiple_profiles_sets_failing(self):
+        # If a single run has the same test multiple times in different
+        # profiles, the failures are captured and reported even if
+        # successes are signaled after that.
+        repo = self.repo_impl.initialise(self.sample_url)
+        result = repo.get_inserter(profiles=set(['p1', 'p2', 'p3']))
+        result.startTestRun()
+        now = datetime.now(tz=iso8601.Utc())
+        result.status(
+            test_id='testid', test_tags=set(['p1']), test_status='success',
+            timestamp=now)
+        result.status(
+            test_id='testid', test_tags=set(['p2']), test_status='fail',
+            timestamp=now)
+        result.status(
+            test_id='testid', test_tags=set(['p3']), test_status='success',
+            timestamp=now)
+        result.stopTestRun()
+        analyzed = self.get_failing_list(repo)
+        self.assertEqual([{'details': {},
+            'id': 'testid',
+            'status': 'fail',
+            'tags': set(['p2']),
+            'timestamps': [now, now]}], analyzed)
+
+    def test_insert_multiple_profiles_partial_updates(self):
+        # If a single run has the same test multiple times in different
+        # profiles, the failures are captured and reported distinctly.
+        # p1, p2 fail
+        repo = self.repo_impl.initialise(self.sample_url)
+        result = repo.get_inserter(profiles=set(['p1', 'p2', 'p3']))
+        result.startTestRun()
+        now = datetime.now(tz=iso8601.Utc())
+        result.status(
+            test_id='testid', test_tags=set(['p1']), test_status='fail',
+            timestamp=now)
+        result.status(
+            test_id='testid', test_tags=set(['p2']), test_status='fail',
+            timestamp=now)
+        result.stopTestRun()
+        # Now p1 is missing (and should carry through),
+        # p2 succeeds (and should no longer be reported failing)
+        # and p3 is a new failure and should be reported failing
+        result = repo.get_inserter(
+            partial=True, profiles=set(['p1', 'p2', 'p3']))
+        result.startTestRun()
+        result.status(
+            test_id='testid', test_tags=set(['p2']), test_status='success',
+            timestamp=now)
+        result.status(
+            test_id='testid', test_tags=set(['p3']), test_status='fail',
+            timestamp=now)
+        result.stopTestRun()
+        analyzed = self.get_failing_list(repo)
+        analyzed.sort(key=lambda d:list(d['tags']))
+        self.assertEqual([
+            {'details': {},
+             'id': 'testid',
+             'status': 'fail',
+             'tags': set(['p1']),
+             'timestamps': [now, now]},
+            {'details': {},
+             'id': 'testid',
+             'status': 'fail',
+             'tags': set(['p3']),
+             'timestamps': [now, now]},
+            ], analyzed)
+
+    def test_insert_missing_profile_does_not_reset_other_failing_test(self):
+        # Only the supplied profiles are considered, not arbitrary tags
+        # (otherwise worker-N tags would cause failures to be considered
+        # distinct).
+        repo = self.repo_impl.initialise(self.sample_url)
+        result = repo.get_inserter(profiles=set(['p1', 'p2', 'p3']))
+        result.startTestRun()
+        now = datetime.now(tz=iso8601.Utc())
+        # These two should be considered identical
+        result.status(
+            test_id='testid', test_tags=set(['p1', 't1']), test_status='fail',
+            timestamp=now)
+        result.status(
+            test_id='testid', test_tags=set(['p1', 't2']), test_status='fail',
+            timestamp=now)
+
+        result.stopTestRun()
+        # Now p1 is missing (and should carry through),
+        # p2 succeeds (and should no longer be reported failing)
+        # and p3 is a new failure and should be reported failing
+        result = repo.get_inserter(
+            partial=True, profiles=set(['p1', 'p2', 'p3']))
+        result.startTestRun()
+        result.status(
+            test_id='testid', test_tags=set(['p2']), test_status='success',
+            timestamp=now)
+        result.status(
+            test_id='testid', test_tags=set(['p3']), test_status='fail',
+            timestamp=now)
+        result.stopTestRun()
+        analyzed = self.get_failing_list(repo)
+        analyzed.sort(key=lambda d:list(d['tags']))
+        self.assertEqual([
+            {'details': {},
+             'id': 'testid',
+             'status': 'fail',
+             'tags': set(['p1', 't2']),
+             'timestamps': [now, now]},
+            {'details': {},
+             'id': 'testid',
+             'status': 'fail',
+             'tags': set(['p3']),
+             'timestamps': [now, now]},
+            ], analyzed)
+
+    def test_insert_non_profile_tags_ignored_for_failing_deduplication(self):
+        # Only the supplied profiles are considered, not arbitrary tags
+        # (otherwise worker-N tags would cause failures to be considered
+        # distinct).
+        repo = self.repo_impl.initialise(self.sample_url)
+        result = repo.get_inserter(profiles=['p1'])
+        result.startTestRun()
+        now = datetime.now(tz=iso8601.Utc())
+        # These two should be considered identical
+        result.status(
+            test_id='testid', test_tags=set(['p1', 't1']), test_status='fail',
+            timestamp=now)
+        result.status(
+            test_id='testid', test_tags=set(['p1', 't2']), test_status='fail',
+            timestamp=now)
+        result.stopTestRun()
+        analyzed = self.get_failing_list(repo)
+        self.assertEqual([
+            {'details': {},
+             'id': 'testid',
+             'status': 'fail',
+             'tags': set(['p1', 't2']), # The most recent one wins
+             'timestamps': [now, now]},
+            ], analyzed)
+        # On updates this applies too
+        result = repo.get_inserter(partial=True, profiles=['p1'])
+        result.startTestRun()
+        result.status(
+            test_id='testid', test_tags=set(['p1']), test_status='fail',
+            timestamp=now)
+        result.stopTestRun()
+        analyzed = self.get_failing_list(repo)
+        self.assertEqual([
+            {'details': {},
+             'id': 'testid',
+             'status': 'fail',
+             'tags': set(['p1']),
+             'timestamps': [now, now]},
+            ], analyzed)
+        # Including fail -> success transitions.
+        result = repo.get_inserter(partial=True, profiles=['p1'])
+        result.startTestRun()
+        result.status(
+            test_id='testid', test_tags=set(['p1']), test_status='success',
+            timestamp=now)
+        result.stopTestRun()
+        analyzed = self.get_failing_list(repo)
+        self.assertEqual([], analyzed)

--- a/testrepository/tests/test_repository.py
+++ b/testrepository/tests/test_repository.py
@@ -593,6 +593,10 @@ class TestRepositoryContract(ResourcedTestCase):
             timestamp=now)
         result.stopTestRun()
         analyzed = self.get_failing_list(repo)
+        # Note - this fails sporadically on pypy3 w/file repo on a differing
+        # microsecond! (Odd with a fixed timestamp, but there you are) - I
+        # think the migration of the repo to v2 will fix this, thus tolerating
+        # it for now.
         self.assertEqual([{'details': {},
             'id': 'testid',
             'status': 'fail',
@@ -673,7 +677,7 @@ class TestRepositoryContract(ResourcedTestCase):
             timestamp=now)
         result.stopTestRun()
         analyzed = self.get_failing_list(repo)
-        analyzed.sort(key=lambda d:list(d['tags']))
+        analyzed.sort(key=lambda d:sorted(d['tags']))
         self.assertEqual([
             {'details': {},
              'id': 'testid',

--- a/testrepository/tests/test_setup.py
+++ b/testrepository/tests/test_setup.py
@@ -19,6 +19,8 @@ import os.path
 import subprocess
 import sys
 
+import fixtures
+
 from testtools import (
     TestCase,
     )
@@ -32,10 +34,12 @@ class TestCanSetup(TestCase):
     def test_bdist(self):
         # Single smoke test to make sure we can build a package.
         path = os.path.join(os.path.dirname(__file__), '..', '..', 'setup.py')
-        proc = subprocess.Popen([sys.executable, path, 'bdist'],
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT, universal_newlines=True)
-        output, err = proc.communicate()
+        with fixtures.TempDir() as d:
+            proc = subprocess.Popen(
+                [sys.executable, path, 'bdist', '-b', d.path],
+                stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT, universal_newlines=True)
+            output, err = proc.communicate()
         self.assertThat(output, MatchesAny(
             # win32
             DocTestMatches("""...
@@ -45,7 +49,7 @@ Installing testr script...
 ...""", doctest.ELLIPSIS),
             # unixen
             DocTestMatches("""...
-Installing testr script to build/.../bin
+Installing testr script to .../dumb/.../bin
 ...""", doctest.ELLIPSIS)
             ))
         self.assertEqual(0, proc.returncode,

--- a/testrepository/tests/test_testcommand.py
+++ b/testrepository/tests/test_testcommand.py
@@ -547,6 +547,40 @@ class TestTestCommand(ResourcedTestCase):
         self.assertEqual(None, fixture.callout_concurrency())
         self.assertEqual([], ui.outputs)
 
+    def test_default_profiles(self):
+        ui, command = self.get_test_ui_and_cmd()
+        ui.proc_outputs = [_b('py27 py34')]
+        self.set_config(
+            '[DEFAULT]\ndefault_profiles=probe\n'
+            'test_command=foo\n')
+        fixture = self.useFixture(command.get_run_command())
+        self.assertEqual(set(['py27', 'py34']), fixture.default_profiles())
+        self.assertEqual([
+            ('popen', ('probe',), {'shell': True, 'stdin': -1, 'stdout': -1}),
+            ('communicate',)], ui.outputs)
+
+    def test_default_profiles_failed(self):
+        ui, command = self.get_test_ui_and_cmd()
+        ui.proc_results = [1]
+        self.set_config(
+            '[DEFAULT]\ndefault_profiles=probe\n'
+            'test_command=foo\n')
+        fixture = self.useFixture(command.get_run_command())
+        self.assertThat(lambda:fixture.default_profiles(), raises(
+            ValueError("default_profiles failed: exit code 1, stderr=''")))
+        self.assertEqual([
+            ('popen', ('probe',), {'shell': True, 'stdin': -1, 'stdout': -1}),
+            ('communicate',)], ui.outputs)
+
+    def test_default_profiles_not_set(self):
+        ui, command = self.get_test_ui_and_cmd()
+        self.set_config(
+            '[DEFAULT]\n'
+            'test_command=foo\n')
+        fixture = self.useFixture(command.get_run_command())
+        self.assertEqual(set(), fixture.default_profiles())
+        self.assertEqual([], ui.outputs)
+
     def test_list_profiles(self):
         ui, command = self.get_test_ui_and_cmd()
         ui.proc_outputs = [_b('py27 py34')]

--- a/testrepository/tests/test_testcommand.py
+++ b/testrepository/tests/test_testcommand.py
@@ -14,6 +14,8 @@
 
 """Tests for the testcommand module."""
 
+from __future__ import unicode_literals
+
 from io import BytesIO
 import os.path
 import optparse
@@ -109,8 +111,8 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ntest_command=foo\n'
             'instance_dispose=bar $INSTANCE_IDS\n')
-        command._instance_cache.add(Instance(_b('baz')))
-        command._instance_cache.add(Instance(_b('quux')))
+        command._instance_cache.add(Instance('baz'))
+        command._instance_cache.add(Instance('quux'))
         command.cleanUp()
         command.setUp()
         self.assertEqual([
@@ -124,8 +126,8 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ntest_command=foo\n'
             'instance_dispose=bar $INSTANCE_IDS\n')
-        command._instance_cache.add(Instance(_b('baz')))
-        command._instance_cache.add(Instance(_b('quux')))
+        command._instance_cache.add(Instance('baz'))
+        command._instance_cache.add(Instance('quux'))
         self.assertThat(command.cleanUp,
             raises(ValueError('Disposing of instances failed, return 1')))
         command.setUp()
@@ -195,7 +197,7 @@ class TestTestCommand(ResourcedTestCase):
             stream.status(test_id='ids', test_status='exists')
             subunit_bytes = buffer.getvalue()
         else:
-            subunit_bytes = _b('returned\nids\n')
+            subunit_bytes = b'returned\nids\n'
         ui.proc_outputs = [subunit_bytes]
         ui.options = optparse.Values()
         ui.options.parallel = True
@@ -254,7 +256,7 @@ class TestTestCommand(ResourcedTestCase):
         ui.here = self.tempdir
         cmd = run.run(ui)
         ui.set_command(cmd)
-        ui.proc_outputs = [_b('returned\ninstances\n')]
+        ui.proc_outputs = [b'returned\ninstances\n']
         command = self.useFixture(TestCommand(ui, None))
         self.set_config(
             '[DEFAULT]\ntest_command=foo $LISTOPT $IDLIST\ntest_id_list_default=whoo yea\n'
@@ -290,10 +292,10 @@ class TestTestCommand(ResourcedTestCase):
             'test_list_option=--list\n'
             'instance_execute=quux $INSTANCE_ID -- $COMMAND\n')
         fixture = self.useFixture(command.get_run_command())
-        command._instance_cache.add(Instance(_b('bar')))
+        command._instance_cache.add(Instance('bar'))
         fixture.list_tests()
         self.assertEqual(1, command._instance_cache.size())
-        self.assertEqual(Instance(b'bar'), command._instance_cache.allocate())
+        self.assertEqual(Instance('bar'), command._instance_cache.allocate())
         self.assertEqual([
             ('values', [('running', 'quux bar -- foo --list whoo yea')]),
             ('popen', ('quux bar -- foo --list whoo yea',),
@@ -317,7 +319,7 @@ class TestTestCommand(ResourcedTestCase):
             stream.status(test_id='ids', test_status='exists')
             subunit_bytes = buffer.getvalue()
         else:
-            subunit_bytes = _b('returned\nids\n')
+            subunit_bytes = b'returned\nids\n'
         ui, command = self.get_test_ui_and_cmd()
         ui.proc_outputs = [subunit_bytes]
         self.set_config(
@@ -432,8 +434,8 @@ class TestTestCommand(ResourcedTestCase):
         ui, command = self.get_test_ui_and_cmd()
         self.set_config(
             '[DEFAULT]\ntest_command=foo $IDLIST\n')
-        command._instance_cache.add(Instance(_b('foo')))
-        command._instance_cache.add(Instance(_b('bar')))
+        command._instance_cache.add(Instance('foo'))
+        command._instance_cache.add(Instance('bar'))
         fixture = self.useFixture(command.get_run_command())
         procs = fixture.run_tests()
         self.assertEqual([
@@ -448,7 +450,7 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ntest_command=foo $IDLIST\n'
             'instance_execute=quux $INSTANCE_ID -- $COMMAND\n')
-        command._instance_cache.add(Instance(_b('bar')))
+        command._instance_cache.add(Instance('bar'))
         fixture = self.useFixture(command.get_run_command(test_ids=['1']))
         procs = fixture.run_tests()
         self.assertEqual([
@@ -471,9 +473,9 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ntest_command=foo $IDLIST\n'
             'instance_execute=quux $INSTANCE_ID -- $COMMAND\n')
-        command._instance_cache.add(Instance(_b('baz')))
+        command._instance_cache.add(Instance('baz'))
         command._instance_cache.allocate()
-        command._instance_cache.add(Instance(_b('bar')))
+        command._instance_cache.add(Instance('bar'))
         fixture = self.useFixture(command.get_run_command(test_ids=['1']))
         procs = fixture.run_tests()
         self.assertEqual([
@@ -489,7 +491,7 @@ class TestTestCommand(ResourcedTestCase):
         procs[0].stdout.read()
         self.assertEqual(0, procs[0].returncode)
         self.assertEqual(2, command._instance_cache.size())
-        self.assertEqual(Instance(b'bar'), command._instance_cache.allocate())
+        self.assertEqual(Instance('bar'), command._instance_cache.allocate())
         self.assertRaises(KeyError, command._instance_cache.allocate)
 
     def test_run_tests_list_file_in_FILES(self):
@@ -497,7 +499,7 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ntest_command=foo $IDFILE\n'
             'instance_execute=quux $INSTANCE_ID $FILES -- $COMMAND\n')
-        command._instance_cache.add(Instance(_b('bar')))
+        command._instance_cache.add(Instance('bar'))
         fixture = self.useFixture(command.get_run_command(test_ids=['1']))
         list_file = fixture.list_file_name
         procs = fixture.run_tests()
@@ -523,7 +525,7 @@ class TestTestCommand(ResourcedTestCase):
 
     def test_callout_concurrency(self):
         ui, command = self.get_test_ui_and_cmd()
-        ui.proc_outputs = [_b('4')]
+        ui.proc_outputs = [b'4']
         self.set_config(
             '[DEFAULT]\ntest_run_concurrency=probe\n'
             'test_command=foo\n')
@@ -557,7 +559,7 @@ class TestTestCommand(ResourcedTestCase):
 
     def test_default_profiles(self):
         ui, command = self.get_test_ui_and_cmd()
-        ui.proc_outputs = [_b('py27 py34')]
+        ui.proc_outputs = [b'py27 py34']
         self.set_config(
             '[DEFAULT]\ndefault_profiles=probe\n'
             'test_command=foo\n')
@@ -591,7 +593,7 @@ class TestTestCommand(ResourcedTestCase):
 
     def test_list_profiles(self):
         ui, command = self.get_test_ui_and_cmd()
-        ui.proc_outputs = [_b('py27 py34')]
+        ui.proc_outputs = [b'py27 py34']
         self.set_config(
             '[DEFAULT]\nlist_profiles=probe\n'
             'test_command=foo\n')
@@ -631,7 +633,7 @@ class TestTestCommand(ResourcedTestCase):
             stream.status(test_id='ids', test_status='exists')
             subunit_bytes = buffer.getvalue()
         else:
-            subunit_bytes = _b('returned\nids\n')
+            subunit_bytes = b'returned\nids\n'
         ui, command = self.get_test_ui_and_cmd()
         ui.proc_outputs = [subunit_bytes]
         self.set_config(
@@ -643,7 +645,7 @@ class TestTestCommand(ResourcedTestCase):
 
     def test_filter_tests_by_regex_supplied_ids(self):
         ui, command = self.get_test_ui_and_cmd()
-        ui.proc_outputs = [_b('returned\nids\n')]
+        ui.proc_outputs = [b'returned\nids\n']
         self.set_config(
             '[DEFAULT]\ntest_command=foo $LISTOPT $IDLIST\ntest_id_list_default=whoo yea\n'
             'test_list_option=--list\n')
@@ -654,7 +656,7 @@ class TestTestCommand(ResourcedTestCase):
 
     def test_filter_tests_by_regex_supplied_ids_multi_match(self):
         ui, command = self.get_test_ui_and_cmd()
-        ui.proc_outputs = [_b('returned\nids\n')]
+        ui.proc_outputs = [b'returned\nids\n']
         self.set_config(
             '[DEFAULT]\ntest_command=foo $LISTOPT $IDLIST\ntest_id_list_default=whoo yea\n'
             'test_list_option=--list\n')

--- a/testrepository/tests/test_testcommand.py
+++ b/testrepository/tests/test_testcommand.py
@@ -456,8 +456,8 @@ class TestTestCommand(ResourcedTestCase):
             ('values', [('running', 'provision -c 2')]),
             ('popen', ('provision -c 2',), {'shell': True, 'stdout': -1}),
             ('communicate',),
-            ('values', [('running', _u('quux I4 P2 -- foo --list '))]),
-            ('popen', (_u('quux I4 P2 -- foo --list '),), {'shell': True, 'stdin': -1, 'stdout': -1}), ('communicate',)
+            ('values', [('running', _u('quux I3 P2 -- foo --list '))]),
+            ('popen', (_u('quux I3 P2 -- foo --list '),), {'shell': True, 'stdin': -1, 'stdout': -1}), ('communicate',)
             ]))
 
     def test_list_tests_multiple_profiles_no_environments(self):
@@ -696,7 +696,7 @@ class TestTestCommand(ResourcedTestCase):
             ui.outputs)
         # No --parallel, so the one instance should have been allocated.
         self.assertEqual(1, command._instance_cache.size('DEFAULT'))
-        self.assertRaises(KeyError, command._instance_cache.allocate, 'DEFAULT')
+        self.assertRaises(Exception, command._instance_cache.allocate, 'DEFAULT')
         # And after the process is run, bar is returned for re-use.
         procs[0].run_proc.stdout.read()
         procs[0].run_proc.wait()
@@ -723,14 +723,14 @@ class TestTestCommand(ResourcedTestCase):
             ui.outputs)
         # No --parallel, so the one instance should have been allocated.
         self.assertEqual(2, command._instance_cache.size('DEFAULT'))
-        self.assertRaises(KeyError, command._instance_cache.allocate, 'DEFAULT')
+        self.assertRaises(Exception, command._instance_cache.allocate, 'DEFAULT')
         # And after the process is run, bar is returned for re-use.
         procs[0].run_proc.wait()
         procs[0].run_proc.stdout.read()
         self.assertEqual(0, procs[0].run_proc.returncode)
         self.assertEqual(2, command._instance_cache.size('DEFAULT'))
         self.assertEqual(Instance('DEFAULT', 'bar'), command._instance_cache.allocate('DEFAULT'))
-        self.assertRaises(KeyError, command._instance_cache.allocate, 'DEFAULT')
+        self.assertRaises(Exception, command._instance_cache.allocate, 'DEFAULT')
 
     def test_run_tests_list_file_in_FILES(self):
         self.set_config(
@@ -750,7 +750,7 @@ class TestTestCommand(ResourcedTestCase):
             ui.outputs)
         # No --parallel, so the one instance should have been allocated.
         self.assertEqual(1, command._instance_cache.size('DEFAULT'))
-        self.assertRaises(KeyError, command._instance_cache.allocate, 'DEFAULT')
+        self.assertRaises(Exception, command._instance_cache.allocate, 'DEFAULT')
         # And after the process is run, bar is returned for re-use.
         procs[0].run_proc.stdout.read()
         procs[0].run_proc.wait()

--- a/testrepository/tests/test_testcommand.py
+++ b/testrepository/tests/test_testcommand.py
@@ -395,8 +395,8 @@ class TestTestCommand(ResourcedTestCase):
         self.useFixture(command)
         fixture = self.useFixture(command.get_run_command())
         self.assertEqual(
-            {u'ids': {'profiles': [u'DEFAULT']},
-             u'returned': {'profiles': [u'DEFAULT']}},
+            {_u('ids'): {'profiles': [_u('DEFAULT')]},
+             _u('returned'): {'profiles': [_u('DEFAULT')]}},
             fixture.list_tests([_u('DEFAULT')]))
 
     def test_list_tests_nonzero_exit(self):
@@ -435,9 +435,9 @@ class TestTestCommand(ResourcedTestCase):
         command = self.useFixture(TestCommand(ui, None))
         fixture = self.useFixture(command.get_run_command())
         self.assertEqual(
-            {u'ids': {'profiles': [u'P1', u'P2']},
-             u'more': {'profiles': [u'P2']},
-             u'returned': {'profiles': [u'P1']}},
+            {_u('ids'): {'profiles': [_u('P1'), _u('P2')]},
+             _u('more'): {'profiles': [_u('P2')]},
+             _u('returned'): {'profiles': [_u('P1')]}},
             fixture.test_ids)
         # Little ugly. We can allocate two, as the list used and released one.
         command._instance_cache.allocate('P1')
@@ -481,9 +481,9 @@ class TestTestCommand(ResourcedTestCase):
         command = self.useFixture(TestCommand(ui, None))
         fixture = self.useFixture(command.get_run_command())
         self.assertEqual(
-            {u'ids': {'profiles': [u'P1', u'P2']},
-             u'more': {'profiles': [u'P2']},
-             u'returned': {'profiles': [u'P1']}},
+            {_u('ids'): {'profiles': [_u('P1'), _u('P2')]},
+             _u('more'): {'profiles': [_u('P2')]},
+             _u('returned'): {'profiles': [_u('P1')]}},
             fixture.list_tests(['P1', 'P2']))
         self.assertThat(ui.outputs, Equals([
             ('popen', ('list_profiles',), {'shell': True, 'stdin': -1, 'stdout': -1}),
@@ -942,6 +942,6 @@ class TestApplyProfiles(ResourcedTestCase):
 
     def test_plain(self):
         self.assertEqual(
-            {u'a': {'profiles': [u'1', u'2']},
-             u'b': {'profiles': [u'1', u'2']}},
+            {_u('a'): {'profiles': [_u('1'), _u('2')]},
+             _u('b'): {'profiles': [_u('1'), _u('2')]}},
             testcommand.apply_profiles(['1', '2'], ['a', 'b']))

--- a/testrepository/tests/test_testcommand.py
+++ b/testrepository/tests/test_testcommand.py
@@ -111,8 +111,8 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ntest_command=foo\n'
             'instance_dispose=bar $INSTANCE_IDS\n')
-        command._instance_cache.add(Instance('baz'))
-        command._instance_cache.add(Instance('quux'))
+        command._instance_cache.add(Instance('p', 'baz'))
+        command._instance_cache.add(Instance('p', 'quux'))
         command.cleanUp()
         command.setUp()
         self.assertEqual([
@@ -126,8 +126,8 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ntest_command=foo\n'
             'instance_dispose=bar $INSTANCE_IDS\n')
-        command._instance_cache.add(Instance('baz'))
-        command._instance_cache.add(Instance('quux'))
+        command._instance_cache.add(Instance('p', 'baz'))
+        command._instance_cache.add(Instance('p', 'quux'))
         self.assertThat(command.cleanUp,
             raises(ValueError('Disposing of instances failed, return 1')))
         command.setUp()
@@ -292,10 +292,10 @@ class TestTestCommand(ResourcedTestCase):
             'test_list_option=--list\n'
             'instance_execute=quux $INSTANCE_ID -- $COMMAND\n')
         fixture = self.useFixture(command.get_run_command())
-        command._instance_cache.add(Instance('bar'))
+        command._instance_cache.add(Instance('p', 'bar'))
         fixture.list_tests()
         self.assertEqual(1, command._instance_cache.size())
-        self.assertEqual(Instance('bar'), command._instance_cache.allocate())
+        self.assertEqual(Instance('p', 'bar'), command._instance_cache.allocate())
         self.assertEqual([
             ('values', [('running', 'quux bar -- foo --list whoo yea')]),
             ('popen', ('quux bar -- foo --list whoo yea',),
@@ -434,8 +434,8 @@ class TestTestCommand(ResourcedTestCase):
         ui, command = self.get_test_ui_and_cmd()
         self.set_config(
             '[DEFAULT]\ntest_command=foo $IDLIST\n')
-        command._instance_cache.add(Instance('foo'))
-        command._instance_cache.add(Instance('bar'))
+        command._instance_cache.add(Instance('p', 'foo'))
+        command._instance_cache.add(Instance('p', 'bar'))
         fixture = self.useFixture(command.get_run_command())
         procs = fixture.run_tests()
         self.assertEqual([
@@ -450,7 +450,7 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ntest_command=foo $IDLIST\n'
             'instance_execute=quux $INSTANCE_ID -- $COMMAND\n')
-        command._instance_cache.add(Instance('bar'))
+        command._instance_cache.add(Instance('p', 'bar'))
         fixture = self.useFixture(command.get_run_command(test_ids=['1']))
         procs = fixture.run_tests()
         self.assertEqual([
@@ -473,9 +473,9 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ntest_command=foo $IDLIST\n'
             'instance_execute=quux $INSTANCE_ID -- $COMMAND\n')
-        command._instance_cache.add(Instance('baz'))
+        command._instance_cache.add(Instance('p', 'baz'))
         command._instance_cache.allocate()
-        command._instance_cache.add(Instance('bar'))
+        command._instance_cache.add(Instance('p', 'bar'))
         fixture = self.useFixture(command.get_run_command(test_ids=['1']))
         procs = fixture.run_tests()
         self.assertEqual([
@@ -491,7 +491,7 @@ class TestTestCommand(ResourcedTestCase):
         procs[0].stdout.read()
         self.assertEqual(0, procs[0].returncode)
         self.assertEqual(2, command._instance_cache.size())
-        self.assertEqual(Instance('bar'), command._instance_cache.allocate())
+        self.assertEqual(Instance('p', 'bar'), command._instance_cache.allocate())
         self.assertRaises(KeyError, command._instance_cache.allocate)
 
     def test_run_tests_list_file_in_FILES(self):
@@ -499,7 +499,7 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ntest_command=foo $IDFILE\n'
             'instance_execute=quux $INSTANCE_ID $FILES -- $COMMAND\n')
-        command._instance_cache.add(Instance('bar'))
+        command._instance_cache.add(Instance('p', 'bar'))
         fixture = self.useFixture(command.get_run_command(test_ids=['1']))
         list_file = fixture.list_file_name
         procs = fixture.run_tests()

--- a/testrepository/tests/test_testcommand.py
+++ b/testrepository/tests/test_testcommand.py
@@ -47,8 +47,8 @@ from testrepository.tests.test_repository import run_timed
 
 class FakeTestCommand(TestCommand):
 
-    def __init__(self, ui, repo):
-        TestCommand.__init__(self, ui, repo)
+    def __init__(self, ui, repo, profiles=None):
+        TestCommand.__init__(self, ui, repo, profiles=profiles)
         self.oldschool = True
 
 

--- a/testrepository/tests/test_testcommand.py
+++ b/testrepository/tests/test_testcommand.py
@@ -564,8 +564,9 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ndefault_profiles=probe\n'
             'test_command=foo\n')
-        fixture = self.useFixture(command.get_run_command())
-        self.assertEqual(set(['py27', 'py34']), fixture.default_profiles())
+        self.assertEqual(
+            set(['py27', 'py34']),
+            testcommand._default_profiles(command.get_parser(), ui))
         self.assertEqual([
             ('popen', ('probe',), {'shell': True, 'stdin': -1, 'stdout': -1}),
             ('communicate',)], ui.outputs)
@@ -576,8 +577,8 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ndefault_profiles=probe\n'
             'test_command=foo\n')
-        fixture = self.useFixture(command.get_run_command())
-        self.assertThat(lambda:fixture.default_profiles(), raises(
+        self.assertThat(lambda:testcommand._default_profiles(
+            command.get_parser(), ui), raises(
             ValueError("default_profiles failed: exit code 1, stderr=''")))
         self.assertEqual([
             ('popen', ('probe',), {'shell': True, 'stdin': -1, 'stdout': -1}),
@@ -588,8 +589,9 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\n'
             'test_command=foo\n')
-        fixture = self.useFixture(command.get_run_command())
-        self.assertEqual(set(), fixture.default_profiles())
+        self.assertEqual(
+            set(),
+            testcommand._default_profiles(command.get_parser(), ui))
         self.assertEqual([], ui.outputs)
 
     def test_list_profiles(self):
@@ -598,8 +600,9 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\nlist_profiles=probe\n'
             'test_command=foo\n')
-        fixture = self.useFixture(command.get_run_command())
-        self.assertEqual(set(['py27', 'py34']), fixture.list_profiles())
+        self.assertEqual(
+            set(['py27', 'py34']),
+            testcommand._list_profiles(command.get_parser(), ui))
         self.assertEqual([
             ('popen', ('probe',), {'shell': True, 'stdin': -1, 'stdout': -1}),
             ('communicate',)], ui.outputs)
@@ -610,8 +613,8 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\nlist_profiles=probe\n'
             'test_command=foo\n')
-        fixture = self.useFixture(command.get_run_command())
-        self.assertThat(lambda:fixture.list_profiles(), raises(
+        self.assertThat(lambda:testcommand._list_profiles(
+            command.get_parser(), ui), raises(
             ValueError("list_profiles failed: exit code 1, stderr=''")))
         self.assertEqual([
             ('popen', ('probe',), {'shell': True, 'stdin': -1, 'stdout': -1}),
@@ -622,8 +625,9 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\n'
             'test_command=foo\n')
-        fixture = self.useFixture(command.get_run_command())
-        self.assertEqual(set(), fixture.list_profiles())
+        self.assertEqual(
+            set(),
+            testcommand._list_profiles(command.get_parser(), ui))
         self.assertEqual([], ui.outputs)
 
     def test_filter_tests_by_regex_only(self):

--- a/testrepository/tests/ui/test_cli.py
+++ b/testrepository/tests/ui/test_cli.py
@@ -17,6 +17,7 @@
 
 import doctest
 from io import BytesIO, StringIO, TextIOWrapper
+import json
 import optparse
 import os
 import sys
@@ -28,6 +29,7 @@ import testtools
 from testtools import TestCase
 from testtools.compat import _b, _u
 from testtools.matchers import (
+    Equals,
     DocTestMatches,
     MatchesException,
     )
@@ -185,6 +187,30 @@ AssertionError: quux...
             DocTestMatches(
                 '...TestCLIUI.test_outputs_tests_to_stdout\n'
                 '...TestCLIUI.test_construct\n', doctest.ELLIPSIS))
+
+    def test_outputs_tests_meta_to_stdout_json(self):
+        ui, cmd = get_test_ui_and_cmd()
+        tests = {
+            'foo': {'profiles': ['1', '2']},
+            'bar': {'profiles': ['3', '4']},
+            }
+        ui.output_tests_meta(tests, 'json')
+        expected_bytes = json.dumps(tests, sort_keys=True).encode('utf8')
+        self.assertThat(
+            ui._stdout.buffer.getvalue(),
+            Equals(expected_bytes))
+
+    def test_outputs_tests_meta_to_stdout_list(self):
+        ui, cmd = get_test_ui_and_cmd()
+        tests = {
+            'foo': {'profiles': ['1', '2']},
+            'bar': {'profiles': ['3', '4']},
+            }
+        ui.output_tests_meta(tests, 'list')
+        expected_bytes = _b('bar\nfoo\n')
+        self.assertThat(
+            ui._stdout.buffer.getvalue(),
+            Equals(expected_bytes))
 
     def test_outputs_values_to_stdout(self):
         ui, cmd = get_test_ui_and_cmd()

--- a/testrepository/ui/__init__.py
+++ b/testrepository/ui/__init__.py
@@ -22,6 +22,9 @@ See AbstractUI for details on what UI classes should do and are responsible
 for.
 """
 
+from io import BytesIO
+import json
+
 from testtools import StreamResult
 
 from testrepository.results import SummarizingResult
@@ -164,6 +167,27 @@ class AbstractUI(object):
             the delta is unknown or inappropriate.
         """
         raise NotImplementedError(self.output_summary)
+
+    def output_tests(self, tests):
+        """Output a list of tests."""
+        raise NotImplementedError(self.output_tests)
+
+    def output_tests_meta(self, tests, style):
+        """Output a test meta dict.
+
+        :param tests: A dict of testname -> testmetadata dicts.
+        :param style: One of 'json', 'list'.
+        """
+        stream = BytesIO()
+        if style == 'json':
+            stream.write(json.dumps(tests, sort_keys=True).encode('utf8'))
+        elif style == 'list':
+            for id in sorted(tests):
+                stream.write(('%s\n' % id).encode('utf8'))
+        else:
+            raise Exception('unknown style %r' % (style,))
+        stream.seek(0)
+        self.output_stream(stream)
 
     def set_command(self, cmd):
         """Inform the UI what command it is running.

--- a/testrepository/ui/model.py
+++ b/testrepository/ui/model.py
@@ -164,6 +164,11 @@ class UI(ui.AbstractUI):
         """Output a list of tests."""
         self.outputs.append(('tests', tests))
 
+    def output_tests_meta(self, tests, style):
+        if style not in ('json', 'list'):
+            raise Exception('unknown style %r' % (style,))
+        self.outputs.append(('tests_meta', tests, style))
+
     def output_values(self, values):
         self.outputs.append(('values', values))
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -11,7 +11,7 @@ Needs a locally edited .testr.conf
  test_list_option=--list
  ;filter_tags=worker-0
 +list_profiles=echo 2.6 2.7 3.2 3.3 3.4 3.5 cpython pypy pypy3
-+instance_provision=tools/start-container $INSTANCE_PROFILE $INSTANCE_COUNT
++instance_provision=tools/start-container $PROFILE $INSTANCE_COUNT
 +;instance_dispose=
-+instance_execute=tools/run-container $INSTANCE_PROFILE $INSTANCE_ID $FILES -- $COMMAND
++instance_execute=tools/run-container $PROFILE $INSTANCE_ID $FILES -- $COMMAND
 ```

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,17 @@
+Example scripts for doing environments/parallel with containers. Use at own
+risk. We'll get something properly supportable and so on together (unless
+someone else writes it!) at some point.
+
+Needs a locally edited .testr.conf
+```
+--- a/.testr.conf
++++ b/.testr.conf
+@@ -3,3 +3,7 @@ test_command=${PYTHON:-python} -m subunit.run discover $LISTOPT $IDOPTION
+ test_id_option=--load-list $IDFILE
+ test_list_option=--list
+ ;filter_tags=worker-0
++list_profiles=echo 2.6 2.7 3.2 3.3 3.4 3.5 cpython pypy pypy3
++instance_provision=tools/start-container $INSTANCE_PROFILE $INSTANCE_COUNT
++;instance_dispose=
++instance_execute=tools/run-container $INSTANCE_PROFILE $INSTANCE_ID $FILES -- $COMMAND
+```

--- a/tools/run-container
+++ b/tools/run-container
@@ -16,11 +16,6 @@ function container {
 profile=$1
 instance=$2
 shift 2
-if [ "$profile" = "DEFAULT" ]; then
-  # Nothing to do - we're local.
-  exec $@
-fi
-container $profile
 files=
 # accumulate files to copy
 while [ "--" != "$1" ]; do
@@ -28,6 +23,11 @@ while [ "--" != "$1" ]; do
   shift ;
 done
 shift # --
+if [ "$profile" = "DEFAULT" ]; then
+  # Nothing to do - we're local.
+  exec $@
+fi
+container $profile
 echo copying $files to node.
 for f in $files; do
   rsync $f $host:$(dirname $f) ;

--- a/tools/run-container
+++ b/tools/run-container
@@ -24,9 +24,7 @@ function start {
 
 profile=$1
 instance=$2
-profile=2.7
-instance=$1
-shift 1
+shift 2
 container $profile
 files=
 # accumulate files to copy

--- a/tools/run-container
+++ b/tools/run-container
@@ -13,18 +13,13 @@ function container {
   return 0
 }
 
-function start {
-  local host=$1
-  local state=$(sudo lxc-info -s -H -n $host)
-  if [ "RUNNING" != "$state" ]; then
-    sudo lxc-start -d -n $host
-    sudo lxc-wait -n $host -s RUNNING -t 2
-  fi
-}
-
 profile=$1
 instance=$2
 shift 2
+if [ "$profile" = "DEFAULT" ]; then
+  # Nothing to do - we're local.
+  exec $@
+fi
 container $profile
 files=
 # accumulate files to copy

--- a/tools/run-container
+++ b/tools/run-container
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -e
+
+function container {
+  local version=$1
+  host=$(ls ~/.virtualenvs/testrepository-$version-* -d | sed -e "s/^.*testrepository-$version-//")
+  if [ -z "$host" ]; then
+    echo "No host found for $version"
+    return 1
+  fi
+  container=$host
+  return 0
+}
+
+function start {
+  local host=$1
+  local state=$(sudo lxc-info -s -H -n $host)
+  if [ "RUNNING" != "$state" ]; then
+    sudo lxc-start -d -n $host
+    sudo lxc-wait -n $host -s RUNNING -t 2
+  fi
+}
+
+profile=$1
+instance=$2
+profile=2.7
+instance=$1
+shift 1
+container $profile
+files=
+# accumulate files to copy
+while [ "--" != "$1" ]; do
+  files="$files $1"
+  shift ;
+done
+shift # --
+echo copying $files to node.
+for f in $files; do
+  rsync $f $host:$(dirname $f) ;
+done
+echo ssh to $host
+ssh $host "cd $PWD && . ~/.virtualenvs/testrepository-$profile-$host/bin/activate && $@"
+

--- a/tools/start-container
+++ b/tools/start-container
@@ -16,21 +16,25 @@ function container {
 function start {
   local host=$1
   local state=$(sudo lxc-info -s -H -n $host)
+  if [ -z "$state" ]; then
+    echo "host $host does not exist"
+    return 1
+  fi
   if [ "RUNNING" != "$state" ]; then
     sudo lxc-start -d -n $host 1>2
     sudo lxc-wait -n $host -s RUNNING -t 2 1>2
   fi
-  ssh $host "cd $PWD && ~/.virtualenvs/testrepository-$profile-$host/bin/pip install -e .[test] && ~/.virtualenvs/testrepository-$profile-$host/bin/pip uninstall -y testrepository" 1>2
+  ssh $host "cd $PWD && ~/.virtualenvs/testrepository-$profile-$host/bin/pip -q install -e .[test] && ~/.virtualenvs/testrepository-$profile-$host/bin/pip uninstall -y testrepository" 1>&2
 }
 
 profile=$1
-profile=2.7
 count=$2
 container $profile
 # We use one container
 start $host
 # And have no intrinsic concurrency limits
-for i in $(seq 1 4); do #$count); do
+# for i in $(seq 1 4); do #$count); do
+for i in $(seq 1 $count); do
   echo -n " $i"
 done
 echo

--- a/tools/start-container
+++ b/tools/start-container
@@ -24,7 +24,7 @@ function start {
     sudo lxc-start -d -n $host 1>2
     sudo lxc-wait -n $host -s RUNNING -t 2 1>2
   fi
-  ssh $host "cd $PWD && ~/.virtualenvs/testrepository-$profile-$host/bin/pip -q install -e .[test] && ~/.virtualenvs/testrepository-$profile-$host/bin/pip uninstall -y testrepository" 1>&2
+  ssh $host "make --no-print-directory -C $PWD venv=~/.virtualenvs/testrepository-$profile-$host install-for-test" 1>&2
 }
 
 profile=$1

--- a/tools/start-container
+++ b/tools/start-container
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -e
+
+function container {
+  local version=$1
+  host=$(ls ~/.virtualenvs/testrepository-$version-* -d | sed -e "s/^.*testrepository-$version-//")
+  if [ -z "$host" ]; then
+    echo "No host found for $version"
+    return 1
+  fi
+  container=$host
+  return 0
+}
+
+function start {
+  local host=$1
+  local state=$(sudo lxc-info -s -H -n $host)
+  if [ "RUNNING" != "$state" ]; then
+    sudo lxc-start -d -n $host 1>2
+    sudo lxc-wait -n $host -s RUNNING -t 2 1>2
+  fi
+  ssh $host "cd $PWD && ~/.virtualenvs/testrepository-$profile-$host/bin/pip install -e .[test] && ~/.virtualenvs/testrepository-$profile-$host/bin/pip uninstall -y testrepository" 1>2
+}
+
+profile=$1
+profile=2.7
+count=$2
+container $profile
+# We use one container
+start $host
+# And have no intrinsic concurrency limits
+for i in $(seq 1 4); do #$count); do
+  echo -n " $i"
+done
+echo

--- a/tools/start-container
+++ b/tools/start-container
@@ -28,12 +28,14 @@ function start {
 }
 
 profile=$1
+count=$2
 if [ "$profile" = "DEFAULT" ]; then
   # Nothing to do.
-  echo 1
+  for i in $(seq 1 $count); do
+    echo -n " $i"
+  done
   exit 0
 fi
-count=$2
 container $profile
 # We use one container
 start $host

--- a/tools/start-container
+++ b/tools/start-container
@@ -28,6 +28,11 @@ function start {
 }
 
 profile=$1
+if [ "$profile" = "DEFAULT" ]; then
+  # Nothing to do.
+  echo 1
+  exit 0
+fi
 count=$2
 container $profile
 # We use one container


### PR DESCRIPTION
A minimal but functional implementation of multiple profiles, including parallel execution of tests (but not of environment setup), handling of tests that fail in just one profile, and a JSON based extension to listing files to allow specifying tests in arbitrary profiles.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/testing-cabal/testrepository/13)

<!-- Reviewable:end -->
