### PR TITLE
Add a cli option to specify a testr config file

### DIFF
--- a/testrepository/tests/commands/test_list_tests.py
+++ b/testrepository/tests/commands/test_list_tests.py
@@ -70,7 +70,7 @@ class TestCommand(ResourcedTestCase):
         self.assertEqual(1, len(ui.outputs))
         self.assertEqual('error', ui.outputs[0][0])
         self.assertThat(ui.outputs[0][1],
-            MatchesException(ValueError('No .testr.conf config file')))
+            MatchesException(ValueError('No testr config file')))
 
     def test_calls_list_tests(self):
         ui, cmd = self.get_test_ui_and_cmd(args=('--', 'bar', 'quux'))

--- a/testrepository/tests/commands/test_run.py
+++ b/testrepository/tests/commands/test_run.py
@@ -88,7 +88,7 @@ class TestCommand(ResourcedTestCase):
         self.assertEqual(1, len(ui.outputs))
         self.assertEqual('error', ui.outputs[0][0])
         self.assertThat(ui.outputs[0][1],
-            MatchesException(ValueError('No .testr.conf config file')))
+            MatchesException(ValueError('No testr config file')))
 
     def test_no_config_settings_errors(self):
         ui, cmd = self.get_test_ui_and_cmd()
@@ -98,7 +98,7 @@ class TestCommand(ResourcedTestCase):
         self.assertEqual(1, len(ui.outputs))
         self.assertEqual('error', ui.outputs[0][0])
         self.assertThat(ui.outputs[0][1], MatchesException(ValueError(
-            'No test_command option present in .testr.conf')))
+            'No test_command option present in the testr config file')))
 
     def test_IDFILE_failures(self):
         ui, cmd = self.get_test_ui_and_cmd(options=[('failing', True)])

--- a/testrepository/tests/test_testcommand.py
+++ b/testrepository/tests/test_testcommand.py
@@ -130,14 +130,14 @@ class TestTestCommand(ResourcedTestCase):
     def test_get_run_command_no_config_file_errors(self):
         ui, command = self.get_test_ui_and_cmd()
         self.assertThat(command.get_run_command,
-            raises(ValueError('No .testr.conf config file')))
+            raises(ValueError('No testr config file')))
 
     def test_get_run_command_no_config_settings_errors(self):
         ui, command = self.get_test_ui_and_cmd()
         self.set_config('')
         self.assertThat(command.get_run_command,
             raises(ValueError(
-            'No test_command option present in .testr.conf')))
+            'No test_command option present in the testr config file')))
 
     def test_get_run_command_returns_fixture_makes_IDFILE(self):
         ui, command = self.get_test_ui_and_cmd()

--- a/testrepository/ui/cli.py
+++ b/testrepository/ui/cli.py
@@ -269,6 +269,12 @@ class UI(ui.AbstractUI):
             help="Set the directory or url that a command should run from. "
             "This affects all default path lookups but does not affect paths "
             "supplied to the command.", default=os.getcwd(), type=str)
+        parser.add_option("--config", dest="config_path", default=None,
+                          metavar="path",
+                          help="Set a testr config file to use with this "
+                               "command. If one isn't specified then "
+                               ".testr.conf in the directory that a command "
+                               "is running from is used")
         parser.add_option("-q", "--quiet", action="store_true", default=False,
             help="Turn off output other than the primary output for a command "
             "and any errors.")
@@ -288,6 +294,7 @@ class UI(ui.AbstractUI):
         options, args = parser.parse_args(opt_argv)
         args += other_args
         self.here = options.here
+        self.config_path = options.config_path
         self.options = options
         parsed_args = {}
         failed = False

--- a/testrepository/ui/decorator.py
+++ b/testrepository/ui/decorator.py
@@ -54,6 +54,10 @@ class UI(ui.AbstractUI):
     def here(self):
         return self._decorated.here
 
+    @property
+    def config_path(self):
+        return self._decorated.config_path
+
     def _iter_streams(self, stream_type):
         streams = self.input_streams.pop(stream_type, [])
         for stream_value in streams:

--- a/testrepository/ui/model.py
+++ b/testrepository/ui/model.py
@@ -83,7 +83,7 @@ class UI(ui.AbstractUI):
     """
 
     def __init__(self, input_streams=None, options=(), args=(),
-        here='memory:', proc_outputs=(), proc_results=()):
+        here='memory:', proc_outputs=(), proc_results=(), config_path=None):
         """Create a model UI.
 
         :param input_streams: A list of stream name, (file or bytes) tuples to
@@ -95,6 +95,8 @@ class UI(ui.AbstractUI):
             created processes.
         :param proc_results: numeric exit code to be set in each created
             process.
+        :param config_path: The optional path for the config file to use for
+            the command
         """
         self.input_streams = {}
         if input_streams:
@@ -104,6 +106,7 @@ class UI(ui.AbstractUI):
                 self.input_streams.setdefault(stream_type, []).append(
                     stream_value)
         self.here = here
+        self.config_path = config_path
         self.unparsed_opts = options
         self.outputs = []
         # Could take parsed args, but for now this is easier.


### PR DESCRIPTION
This commit adds a new cli option to specify a different testr config.
The default behavior doesn't change. But it enables users to specify
the patch for the testr config to use for a command.
