### PR TITLE
Switch group regex callback to use search instead of match

### DIFF
--- a/testrepository/tests/test_testcommand.py
+++ b/testrepository/tests/test_testcommand.py
@@ -231,6 +231,16 @@ class TestTestCommand(ResourcedTestCase):
         self.assertEqual(
             'pkg.class.', fixture._group_callback('pkg.class.test_method'))
 
+    def test_group_regex_search_option(self):
+        ui, command = self.get_test_ui_and_cmd()
+        self.set_config(
+                '[DEFAULT]\ntest_command=foo $IDOPTION\n'
+                'test_id_option=--load-list $IDFILE\n'
+                'group_regex_search=([^\\.]+\\.)+\n')
+        fixture = self.useFixture(command.get_run_command())
+        self.assertEqual(
+            'pkg.class.', fixture._group_callback('pkg.class.test_method'))
+
     def test_extra_args_passed_in(self):
         ui, command = self.get_test_ui_and_cmd()
         self.set_config(


### PR DESCRIPTION
The use of regex match() as part of the group_callback makes creating
certain group regexes quite difficult. This commit switches to use
search() instead, which is more flexible, and using '^' in your regex
you can emulate the match() behavior.
