### PR TITLE
Isolate testrepository folders by virtual env

### DIFF
--- a/testrepository/setuptools_command.py
+++ b/testrepository/setuptools_command.py
@@ -32,6 +32,7 @@ import os
 import sys
 
 from testrepository import commands
+from testrepository.repository.file import get_base
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
@@ -78,7 +79,7 @@ class Testr(cmd.Command):
     def run(self):
         """Set up testr repo, then run testr"""
         logger.info("run called")
-        if not os.path.isdir(".testrepository"):
+        if not os.path.isdir(get_base()):
             self._run_testr("init")
 
         if self.coverage:

--- a/testrepository/tests/repository/test_file.py
+++ b/testrepository/tests/repository/test_file.py
@@ -55,7 +55,7 @@ class TestFileRepository(ResourcedTestCase):
 
     def test_initialise(self):
         self.useFixture(FileRepositoryFixture(self))
-        base = os.path.join(self.tempdir, '.testrepository')
+        base = file.get_base(self.tempdir)
         stream = open(os.path.join(base, 'format'), 'rt')
         try:
             contents = stream.read()


### PR DESCRIPTION
If testr is run from a virtual environment, use the folder
.testrepository/<virtualenv> as base folder.

Closes-Bug: 1212909
