### PR TITLE
Add option to manual configure the worker balance

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pbr>=1.3
 fixtures
 python-subunit >= 0.0.18
 testtools >= 0.9.30
+PyYAML>=3.1.0

--- a/testrepository/commands/run.py
+++ b/testrepository/commands/run.py
@@ -146,6 +146,10 @@ class run(Command):
         optparse.Option("--isolated", action="store_true",
             default=False,
             help="Run each test id in a separate test runner."),
+        optparse.Option("--worker-file", action="store", type="str",
+                        default=None,
+                        help="Optional path of a manual worker grouping file "
+                             "to use for the run"),
         ]
     args = [StringArgument('testfilters', 0, None), DoubledashArgument(),
         StringArgument('testargs', 0, None)]
@@ -194,7 +198,8 @@ class run(Command):
         try:
             if not self.ui.options.analyze_isolation:
                 cmd = testcommand.get_run_command(ids, self.ui.arguments['testargs'],
-                    test_filters = filters)
+                    test_filters = filters,
+                    worker_path=self.ui.options.worker_file)
                 if self.ui.options.isolated:
                     result = 0
                     cmd.setUp()


### PR DESCRIPTION
This commit adds a new cli option to testr run, --worker-file, which
is the path to a yaml file that describes the breakdown of tests per
workers to explicitly instruct testr how to run tests. The yaml file
format is a list of dicts with a single element with a list describing
the contents of a worker as a regex matching test_ids. For example:
- worker:
  - regex1
- worker:
  - regex2
  - regex3

would spin up 2 workers one running tests matching regex1 and the
other worker running tests matching regex2 and regex3.
