### PR TITLE
Remove python 3.2 testing from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
   - pypy


### PR DESCRIPTION
This commit removes the python 3.2 testing job from the travis.yml.
This job is failing everywhere on pip installs after it upgrades
to pip 8.1.2. Until the pip bug is resolved lets just remove the
tests.
