### PR TITLE
Fix CI badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Test Repository
 +++++++++++++++
 
-.. image:: https://travis-ci.org/testing-cabal/mock.svg?branch=master
-    :target: https://travis-ci.org/testing-cabal/mock
+.. image:: https://travis-ci.org/testing-cabal/testrepository.svg?branch=master
+    :target: https://travis-ci.org/testing-cabal/testrepository
 
 Overview
 ~~~~~~~~


### PR DESCRIPTION
It was pointing at the wrong repo.