### PR TITLE
use pypy rather than pypy2.7 in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
-  - "pypy2.7"
+  - "pypy"
   - "pypy3.5"
 matrix:
   include:

--- a/testrepository/tests/commands/test_load.py
+++ b/testrepository/tests/commands/test_load.py
@@ -232,10 +232,10 @@ class TestCommandLoad(ResourcedTestCase):
         cmd.repository_factory.initialise(ui.here)
         ret = cmd.execute()
         self.assertEqual(
+            ui.outputs,
             [('results', Wildcard),
              ('summary', False, 1, None, None, None,
-                [('id', 0, None), ('failures', 1, None)])],
-            ui.outputs)
+                [('id', 0, None), ('failures', 1, None)])])
         self.assertEqual(1, ret)
 
     def test_partial_passed_to_repo(self):


### PR DESCRIPTION
Use pypy rather than pypy2.7 in travis; the latter doesn't seem to work properly.

Also, change order of arguments to asserEqual() so that tuple equality check uses the right __eq__.

These two changes result in the travis build passing again.