### PR TITLE
Remove compatibility code for pre-0.0.11 versions of subunit.

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -4,7 +4,9 @@ Installing Test Repository
 Run time dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 
-* Python2.4 or newer.
+* Either:
+ + Python 2: version 2.7 or newer
+ + Python 3: version 3.4 or newer
 
 * subunit (0.0.18 or newer).
 

--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,9 @@ CHANGES
 * Unexpected errors reading streams from a file repository now propogate the
   correct exception. (Matthew Treinish, Robert Collins, #1409936)
 
+* testrepository now requires at least version 0.0.11 of the subunit Python
+  module.  (Jelmer Vernooĳ)
+
 0.0.20
 ++++++
 

--- a/testrepository/commands/run.py
+++ b/testrepository/commands/run.py
@@ -19,9 +19,7 @@ from math import ceil
 import optparse
 import re
 
-from extras import try_import
 import subunit
-v2_avail = try_import('subunit.ByteStreamToStreamResult')
 import testtools
 from testtools import (
     TestByTestResult,
@@ -76,16 +74,10 @@ class ReturnCodeToSubunit(object):
                 # - which is not guaranteed in an arbitrary stream endpoint, so
                 # injecting a \n gives us such a guarantee.
                 self.source.write(_b('\n'))
-            if v2_avail:
-                stream = subunit.StreamResultToBytes(self.source)
-                stream.status(test_id='process-returncode', test_status='fail',
-                    file_name='traceback', mime_type='text/plain;charset=utf8',
-                    file_bytes=('returncode %d' % returncode).encode('utf8'))
-            else:
-                self.source.write(_b('test: process-returncode\n'
-                    'failure: process-returncode [\n'
-                    ' returncode %d\n'
-                    ']\n' % returncode))
+            stream = subunit.StreamResultToBytes(self.source)
+            stream.status(test_id='process-returncode', test_status='fail',
+                file_name='traceback', mime_type='text/plain;charset=utf8',
+                file_bytes=('returncode %d' % returncode).encode('utf8'))
         self.source.seek(0)
         self.done = True
 

--- a/testrepository/repository/memory.py
+++ b/testrepository/repository/memory.py
@@ -14,9 +14,7 @@
 
 """In memory storage of test results."""
 
-from extras import try_import
-
-OrderedDict = try_import('collections.OrderedDict', dict)
+from collections import OrderedDict
 from io import BytesIO
 from operator import methodcaller
 

--- a/testrepository/testcommand.py
+++ b/testrepository/testcommand.py
@@ -33,7 +33,7 @@ import multiprocessing
 from textwrap import dedent
 
 from fixtures import Fixture
-v2 = try_import('subunit.v2')
+from subunit import ByteStreamToStreamResult
 
 from testrepository import results
 from testrepository.testlist import (
@@ -300,11 +300,10 @@ class TestListingFixture(Fixture):
                 stdout=subprocess.PIPE, stdin=subprocess.PIPE)
             out, err = run_proc.communicate()
             if run_proc.returncode != 0:
-                if v2 is not None:
-                    new_out = io.BytesIO()
-                    v2.ByteStreamToStreamResult(io.BytesIO(out), 'stdout').run(
-                        results.CatFiles(new_out))
-                    out = new_out.getvalue()
+                new_out = io.BytesIO()
+                ByteStreamToStreamResult(io.BytesIO(out), 'stdout').run(
+                    results.CatFiles(new_out))
+                out = new_out.getvalue()
                 self.ui.output_stream(io.BytesIO(out))
                 self.ui.output_stream(io.BytesIO(err))
                 raise ValueError(

--- a/testrepository/testlist.py
+++ b/testrepository/testlist.py
@@ -16,9 +16,8 @@
 
 from io import BytesIO
 
-from extras import try_import
-bytestream_to_streamresult = try_import('subunit.ByteStreamToStreamResult')
-stream_result = try_import('testtools.testresult.doubles.StreamResult')
+from subunit import ByteStreamToStreamResult
+from testtools.testresult.doubles import StreamResult
 
 from testtools.compat import _b, _u
 
@@ -35,26 +34,14 @@ def write_list(stream, test_ids):
 
 def parse_list(list_bytes):
     """Parse list_bytes into a list of test ids."""
-    return _v1(list_bytes)
+    return [id.strip() for id in list_bytes.decode('utf8').split(_u('\n'))
+            if id.strip()]
 
 
 def parse_enumeration(enumeration_bytes):
     """Parse enumeration_bytes into a list of test_ids."""
-    # If subunit v2 is available, use it.
-    if bytestream_to_streamresult is not None:
-        return _v2(enumeration_bytes)
-    else:
-        return _v1(enumeration_bytes)
-
-
-def _v1(list_bytes):
-    return [id.strip() for id in list_bytes.decode('utf8').split(_u('\n'))
-        if id.strip()]
-
-
-def _v2(list_bytes):
-    parser = bytestream_to_streamresult(BytesIO(list_bytes),
+    parser = ByteStreamToStreamResult(BytesIO(enumeration_bytes),
         non_subunit_name='stdout')
-    result = stream_result()
+    result = StreamResult()
     parser.run(result)
     return [event[1] for event in result._events if event[2]=='exists']

--- a/testrepository/tests/commands/test_list_tests.py
+++ b/testrepository/tests/commands/test_list_tests.py
@@ -18,9 +18,7 @@ from io import BytesIO
 import os.path
 from subprocess import PIPE
 
-from extras import try_import
 import subunit
-v2_avail = try_import('subunit.ByteStreamToStreamResult')
 from testtools.compat import _b
 from testtools.matchers import MatchesException
 
@@ -75,14 +73,11 @@ class TestCommand(ResourcedTestCase):
     def test_calls_list_tests(self):
         ui, cmd = self.get_test_ui_and_cmd(args=('--', 'bar', 'quux'))
         cmd.repository_factory = memory.RepositoryFactory()
-        if v2_avail:
-            buffer = BytesIO()
-            stream = subunit.StreamResultToBytes(buffer)
-            stream.status(test_id='returned', test_status='exists')
-            stream.status(test_id='values', test_status='exists')
-            subunit_bytes = buffer.getvalue()
-        else:
-            subunit_bytes = _b('returned\n\nvalues\n')
+        buffer = BytesIO()
+        stream = subunit.StreamResultToBytes(buffer)
+        stream.status(test_id='returned', test_status='exists')
+        stream.status(test_id='values', test_status='exists')
+        subunit_bytes = buffer.getvalue()
         ui.proc_outputs = [subunit_bytes]
         self.setup_repo(cmd, ui)
         self.set_config(
@@ -103,14 +98,11 @@ class TestCommand(ResourcedTestCase):
         ui, cmd = self.get_test_ui_and_cmd(
             args=('returned', '--', 'bar', 'quux'))
         cmd.repository_factory = memory.RepositoryFactory()
-        if v2_avail:
-            buffer = BytesIO()
-            stream = subunit.StreamResultToBytes(buffer)
-            stream.status(test_id='returned', test_status='exists')
-            stream.status(test_id='values', test_status='exists')
-            subunit_bytes = buffer.getvalue()
-        else:
-            subunit_bytes = _b('returned\nvalues\n')
+        buffer = BytesIO()
+        stream = subunit.StreamResultToBytes(buffer)
+        stream.status(test_id='returned', test_status='exists')
+        stream.status(test_id='values', test_status='exists')
+        subunit_bytes = buffer.getvalue()
         ui.proc_outputs = [subunit_bytes]
         self.setup_repo(cmd, ui)
         self.set_config(

--- a/testrepository/tests/commands/test_load.py
+++ b/testrepository/tests/commands/test_load.py
@@ -18,8 +18,6 @@ from datetime import datetime, timedelta
 from io import BytesIO
 from tempfile import NamedTemporaryFile
 
-from extras import try_import
-v2_avail = try_import('subunit.ByteStreamToStreamResult')
 import subunit
 from subunit import iso8601
 
@@ -115,14 +113,11 @@ class TestCommandLoad(ResourcedTestCase):
         self.assertEqual(0, cmd.execute())
 
     def test_load_returns_1_on_failed_stream(self):
-        if v2_avail:
-            buffer = BytesIO()
-            stream = subunit.StreamResultToBytes(buffer)
-            stream.status(test_id='foo', test_status='inprogress')
-            stream.status(test_id='foo', test_status='fail')
-            subunit_bytes = buffer.getvalue()
-        else:
-            subunit_bytes = _b('test: foo\nfailure: foo\n')
+        buffer = BytesIO()
+        stream = subunit.StreamResultToBytes(buffer)
+        stream.status(test_id='foo', test_status='inprogress')
+        stream.status(test_id='foo', test_status='fail')
+        subunit_bytes = buffer.getvalue()
         ui = UI([('subunit', subunit_bytes)])
         cmd = load.load(ui)
         ui.set_command(cmd)
@@ -131,14 +126,11 @@ class TestCommandLoad(ResourcedTestCase):
         self.assertEqual(1, cmd.execute())
 
     def test_load_new_shows_test_failures(self):
-        if v2_avail:
-            buffer = BytesIO()
-            stream = subunit.StreamResultToBytes(buffer)
-            stream.status(test_id='foo', test_status='inprogress')
-            stream.status(test_id='foo', test_status='fail')
-            subunit_bytes = buffer.getvalue()
-        else:
-            subunit_bytes = b'test: foo\nfailure: foo\n'
+        buffer = BytesIO()
+        stream = subunit.StreamResultToBytes(buffer)
+        stream.status(test_id='foo', test_status='inprogress')
+        stream.status(test_id='foo', test_status='fail')
+        subunit_bytes = buffer.getvalue()
         ui = UI([('subunit', subunit_bytes)])
         cmd = load.load(ui)
         ui.set_command(cmd)
@@ -151,16 +143,13 @@ class TestCommandLoad(ResourcedTestCase):
             ui.outputs[1:])
 
     def test_load_new_shows_test_failure_details(self):
-        if v2_avail:
-            buffer = BytesIO()
-            stream = subunit.StreamResultToBytes(buffer)
-            stream.status(test_id='foo', test_status='inprogress')
-            stream.status(test_id='foo', test_status='fail',
-                file_name="traceback", mime_type='text/plain;charset=utf8',
-                file_bytes=b'arg\n')
-            subunit_bytes = buffer.getvalue()
-        else:
-            subunit_bytes = b'test: foo\nfailure: foo [\narg\n]\n'
+        buffer = BytesIO()
+        stream = subunit.StreamResultToBytes(buffer)
+        stream.status(test_id='foo', test_status='inprogress')
+        stream.status(test_id='foo', test_status='fail',
+            file_name="traceback", mime_type='text/plain;charset=utf8',
+            file_bytes=b'arg\n')
+        subunit_bytes = buffer.getvalue()
         ui = UI([('subunit', subunit_bytes)])
         cmd = load.load(ui)
         ui.set_command(cmd)
@@ -183,14 +172,11 @@ class TestCommandLoad(ResourcedTestCase):
         self.assertEqual(1, len(result.errors))
 
     def test_load_new_shows_test_skips(self):
-        if v2_avail:
-            buffer = BytesIO()
-            stream = subunit.StreamResultToBytes(buffer)
-            stream.status(test_id='foo', test_status='inprogress')
-            stream.status(test_id='foo', test_status='skip')
-            subunit_bytes = buffer.getvalue()
-        else:
-            subunit_bytes = b'test: foo\nskip: foo\n'
+        buffer = BytesIO()
+        stream = subunit.StreamResultToBytes(buffer)
+        stream.status(test_id='foo', test_status='inprogress')
+        stream.status(test_id='foo', test_status='skip')
+        subunit_bytes = buffer.getvalue()
         ui = UI([('subunit', subunit_bytes)])
         cmd = load.load(ui)
         ui.set_command(cmd)
@@ -251,20 +237,13 @@ class TestCommandLoad(ResourcedTestCase):
             cmd.repository_factory.repos[ui.here].get_test_run(0)._partial)
 
     def test_load_timed_run(self):
-        if v2_avail:
-            buffer = BytesIO()
-            stream = subunit.StreamResultToBytes(buffer)
-            time = datetime(2011, 1, 1, 0, 0, 1, tzinfo=iso8601.Utc())
-            stream.status(test_id='foo', test_status='inprogress', timestamp=time)
-            stream.status(test_id='foo', test_status='success',
-                timestamp=time+timedelta(seconds=2))
-            timed_bytes = buffer.getvalue()
-        else:
-            timed_bytes = _b('time: 2011-01-01 00:00:01.000000Z\n'
-               'test: foo\n'
-               'time: 2011-01-01 00:00:03.000000Z\n'
-               'success: foo\n'
-               'time: 2011-01-01 00:00:06.000000Z\n')
+        buffer = BytesIO()
+        stream = subunit.StreamResultToBytes(buffer)
+        time = datetime(2011, 1, 1, 0, 0, 1, tzinfo=iso8601.Utc())
+        stream.status(test_id='foo', test_status='inprogress', timestamp=time)
+        stream.status(test_id='foo', test_status='success',
+            timestamp=time+timedelta(seconds=2))
+        timed_bytes = buffer.getvalue()
         ui = UI(
             [('subunit', timed_bytes)])
         cmd = load.load(ui)
@@ -284,27 +263,17 @@ class TestCommandLoad(ResourcedTestCase):
         # If there's a previous run in the database, then show information
         # about the high level differences in the test run: how many more
         # tests, how many more failures, how much longer it takes.
-        if v2_avail:
-            buffer = BytesIO()
-            stream = subunit.StreamResultToBytes(buffer)
-            time = datetime(2011, 1, 2, 0, 0, 1, tzinfo=iso8601.Utc())
-            stream.status(test_id='foo', test_status='inprogress', timestamp=time)
-            stream.status(test_id='foo', test_status='fail',
-                timestamp=time+timedelta(seconds=2))
-            stream.status(test_id='bar', test_status='inprogress',
-                timestamp=time+timedelta(seconds=4))
-            stream.status(test_id='bar', test_status='fail',
-                timestamp=time+timedelta(seconds=6))
-            timed_bytes = buffer.getvalue()
-        else:
-            timed_bytes = _b('time: 2011-01-02 00:00:01.000000Z\n'
-               'test: foo\n'
-               'time: 2011-01-02 00:00:03.000000Z\n'
-               'error: foo\n'
-               'time: 2011-01-02 00:00:05.000000Z\n'
-               'test: bar\n'
-               'time: 2011-01-02 00:00:07.000000Z\n'
-               'error: bar\n')
+        buffer = BytesIO()
+        stream = subunit.StreamResultToBytes(buffer)
+        time = datetime(2011, 1, 2, 0, 0, 1, tzinfo=iso8601.Utc())
+        stream.status(test_id='foo', test_status='inprogress', timestamp=time)
+        stream.status(test_id='foo', test_status='fail',
+            timestamp=time+timedelta(seconds=2))
+        stream.status(test_id='bar', test_status='inprogress',
+            timestamp=time+timedelta(seconds=4))
+        stream.status(test_id='bar', test_status='fail',
+            timestamp=time+timedelta(seconds=6))
+        timed_bytes = buffer.getvalue()
         ui = UI(
             [('subunit', timed_bytes)])
         cmd = load.load(ui)

--- a/testrepository/tests/commands/test_run.py
+++ b/testrepository/tests/commands/test_run.py
@@ -19,13 +19,11 @@ import os.path
 from subprocess import PIPE
 import tempfile
 
-from extras import try_import
 from fixtures import (
     Fixture,
     MonkeyPatch,
     )
 import subunit
-v2_avail = try_import('subunit.ByteStreamToStreamResult')
 from subunit import RemotedTestCase
 from testscenarios.scenarios import multiply_scenarios
 from testtools.compat import _b
@@ -298,14 +296,11 @@ class TestCommand(ResourcedTestCase):
             cmd.repository_factory.repos[ui.here].get_test_run(1)._partial)
 
     def test_load_failure_exposed(self):
-        if v2_avail:
-            buffer = BytesIO()
-            stream = subunit.StreamResultToBytes(buffer)
-            stream.status(test_id='foo', test_status='inprogress')
-            stream.status(test_id='foo', test_status='fail')
-            subunit_bytes = buffer.getvalue()
-        else:
-            subunit_bytes = b'test: foo\nfailure: foo\n'
+        buffer = BytesIO()
+        stream = subunit.StreamResultToBytes(buffer)
+        stream.status(test_id='foo', test_status='inprogress')
+        stream.status(test_id='foo', test_status='fail')
+        subunit_bytes = buffer.getvalue()
         ui, cmd = self.get_test_ui_and_cmd(options=[('quiet', True),],
             proc_outputs=[subunit_bytes])
         cmd.repository_factory = memory.RepositoryFactory()
@@ -316,14 +311,11 @@ class TestCommand(ResourcedTestCase):
         self.assertEqual(1, result)
 
     def test_process_exit_code_nonzero_causes_synthetic_error_test(self):
-        if v2_avail:
-            buffer = BytesIO()
-            stream = subunit.StreamResultToBytes(buffer)
-            stream.status(test_id='foo', test_status='inprogress')
-            stream.status(test_id='foo', test_status='success')
-            subunit_bytes = buffer.getvalue()
-        else:
-            subunit_bytes = b'test: foo\nsuccess: foo\n'
+        buffer = BytesIO()
+        stream = subunit.StreamResultToBytes(buffer)
+        stream.status(test_id='foo', test_status='inprogress')
+        stream.status(test_id='foo', test_status='success')
+        subunit_bytes = buffer.getvalue()
         ui, cmd = self.get_test_ui_and_cmd(options=[('quiet', True),],
             proc_outputs=[subunit_bytes],
             proc_results=[2])
@@ -390,20 +382,16 @@ class TestCommand(ResourcedTestCase):
 
     def test_until_failure(self):
         ui, cmd = self.get_test_ui_and_cmd(options=[('until_failure', True)])
-        if v2_avail:
-            buffer = BytesIO()
-            stream = subunit.StreamResultToBytes(buffer)
-            stream.status(test_id='foo', test_status='inprogress')
-            stream.status(test_id='foo', test_status='success')
-            subunit_bytes1 = buffer.getvalue()
-            buffer.seek(0)
-            buffer.truncate()
-            stream.status(test_id='foo', test_status='inprogress')
-            stream.status(test_id='foo', test_status='fail')
-            subunit_bytes2 = buffer.getvalue()
-        else:
-            subunit_bytes1 = b'test: foo\nsuccess: foo\n'
-            subunit_bytes2 = b'test: foo\nfailure: foo\n'
+        buffer = BytesIO()
+        stream = subunit.StreamResultToBytes(buffer)
+        stream.status(test_id='foo', test_status='inprogress')
+        stream.status(test_id='foo', test_status='success')
+        subunit_bytes1 = buffer.getvalue()
+        buffer.seek(0)
+        buffer.truncate()
+        stream.status(test_id='foo', test_status='inprogress')
+        stream.status(test_id='foo', test_status='fail')
+        subunit_bytes2 = buffer.getvalue()
         ui.proc_outputs = [
             subunit_bytes1, # stream one, works
             subunit_bytes2, # stream two, fails
@@ -527,15 +515,11 @@ class TestReturnCodeToSubunit(ResourcedTestCase):
         proc.returncode = 1
         stream = run.ReturnCodeToSubunit(proc)
         content = accumulate(stream, self.reader)
-        if v2_avail:
-            buffer = BytesIO()
-            buffer.write(b'foo\nbar\n')
-            stream = subunit.StreamResultToBytes(buffer)
-            stream.status(test_id='process-returncode', test_status='fail',
-                file_name='traceback', mime_type='text/plain;charset=utf8',
-                file_bytes=b'returncode 1')
-            expected_content = buffer.getvalue()
-        else:
-            expected_content = _b('foo\nbar\ntest: process-returncode\n'
-                'failure: process-returncode [\n returncode 1\n]\n')
+        buffer = BytesIO()
+        buffer.write(b'foo\nbar\n')
+        stream = subunit.StreamResultToBytes(buffer)
+        stream.status(test_id='process-returncode', test_status='fail',
+            file_name='traceback', mime_type='text/plain;charset=utf8',
+            file_bytes=b'returncode 1')
+        expected_content = buffer.getvalue()
         self.assertEqual(expected_content, content)

--- a/testrepository/tests/test_testcommand.py
+++ b/testrepository/tests/test_testcommand.py
@@ -19,9 +19,7 @@ import os.path
 import optparse
 import re
 
-from extras import try_import
 import subunit
-v2_avail = try_import('subunit.ByteStreamToStreamResult')
 from testtools.compat import _b
 from testtools.matchers import (
     Equals,
@@ -185,14 +183,11 @@ class TestTestCommand(ResourcedTestCase):
 
     def test_get_run_command_default_and_list_expands(self):
         ui, command = self.get_test_ui_and_cmd()
-        if v2_avail:
-            buffer = BytesIO()
-            stream = subunit.StreamResultToBytes(buffer)
-            stream.status(test_id='returned', test_status='exists')
-            stream.status(test_id='ids', test_status='exists')
-            subunit_bytes = buffer.getvalue()
-        else:
-            subunit_bytes = _b('returned\nids\n')
+        buffer = BytesIO()
+        stream = subunit.StreamResultToBytes(buffer)
+        stream.status(test_id='returned', test_status='exists')
+        stream.status(test_id='ids', test_status='exists')
+        subunit_bytes = buffer.getvalue()
         ui.proc_outputs = [subunit_bytes]
         ui.options = optparse.Values()
         ui.options.parallel = True
@@ -305,14 +300,11 @@ class TestTestCommand(ResourcedTestCase):
         self.assertEqual(expected_cmd, fixture.list_cmd)
 
     def test_list_tests_parsing(self):
-        if v2_avail:
-            buffer = BytesIO()
-            stream = subunit.StreamResultToBytes(buffer)
-            stream.status(test_id='returned', test_status='exists')
-            stream.status(test_id='ids', test_status='exists')
-            subunit_bytes = buffer.getvalue()
-        else:
-            subunit_bytes = _b('returned\nids\n')
+        buffer = BytesIO()
+        stream = subunit.StreamResultToBytes(buffer)
+        stream.status(test_id='returned', test_status='exists')
+        stream.status(test_id='ids', test_status='exists')
+        subunit_bytes = buffer.getvalue()
         ui, command = self.get_test_ui_and_cmd()
         ui.proc_outputs = [subunit_bytes]
         self.set_config(
@@ -548,14 +540,11 @@ class TestTestCommand(ResourcedTestCase):
         self.assertEqual([], ui.outputs)
 
     def test_filter_tests_by_regex_only(self):
-        if v2_avail:
-            buffer = BytesIO()
-            stream = subunit.StreamResultToBytes(buffer)
-            stream.status(test_id='returned', test_status='exists')
-            stream.status(test_id='ids', test_status='exists')
-            subunit_bytes = buffer.getvalue()
-        else:
-            subunit_bytes = _b('returned\nids\n')
+        buffer = BytesIO()
+        stream = subunit.StreamResultToBytes(buffer)
+        stream.status(test_id='returned', test_status='exists')
+        stream.status(test_id='ids', test_status='exists')
+        subunit_bytes = buffer.getvalue()
         ui, command = self.get_test_ui_and_cmd()
         ui.proc_outputs = [subunit_bytes]
         self.set_config(

--- a/testrepository/ui/cli.py
+++ b/testrepository/ui/cli.py
@@ -20,8 +20,6 @@ import signal
 import subunit
 import sys
 
-from extras import try_import
-v2_avail = try_import('subunit.ByteStreamToStreamResult')
 import testtools
 from testtools import ExtendedToStreamDecorator, StreamToExtendedDecorator
 from testtools.compat import unicode_output_stream, _u
@@ -107,11 +105,7 @@ class UI(ui.AbstractUI):
 
     def make_result(self, get_id, test_command, previous_run=None):
         if getattr(self.options, 'subunit', False):
-            if v2_avail:
-                serializer = subunit.StreamResultToBytes(self._stdout)
-            else:
-                serializer = StreamToExtendedDecorator(
-                    subunit.TestProtocolClient(self._stdout))
+            serializer = subunit.StreamResultToBytes(self._stdout)
             # By pass user transforms - just forward it all,
             result = serializer
             # and interpret everything as success.


### PR DESCRIPTION
requirements.txt and INSTALL.txt suggest testrepository requires subunit v0.0.18, but there is still a lot of compatibility code for subunit < 0.0.11. 