### PR TITLE
Add missing extras library to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 pbr>=1.3
+extras
 fixtures
 python-subunit >= 0.0.18
 testtools >= 0.9.30


### PR DESCRIPTION
The extras library is required to use this library.