### PR TITLE
Drop Python 2 support

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -4,9 +4,7 @@ Installing Test Repository
 Run time dependencies
 ~~~~~~~~~~~~~~~~~~~~~
 
-* Either:
- + Python 2: version 2.7 or newer
- + Python 3: version 3.4 or newer
+* Python 3: version 3.4 or newer
 
 * subunit (0.0.18 or newer).
 

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,14 @@
 testrepository release notes
 ############################
 
+0.0.22
+++++++
+
+CHANGES
+-------
+
+* Drop Python 2 support. (Colin Watson)
+
 0.0.21
 ++++++
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,6 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "License :: OSI Approved :: BSD License",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python",
     "Topic :: Software Development :: Quality Assurance",

--- a/testrepository/arguments/__init__.py
+++ b/testrepository/arguments/__init__.py
@@ -31,8 +31,6 @@ containing their argument types - no __init__ is needed in that directory.)
 
 import sys
 
-from testtools.compat import reraise
-
 
 class AbstractArgument(object):
     """A argument that a command may need.
@@ -101,7 +99,7 @@ class AbstractArgument(object):
                 break
         if count < self.minimum_count:
             if error is not None:
-                reraise(error[0], error[1], error[2])
+                raise error[1].with_traceback(error[2])
             raise ValueError('not enough arguments present/matched in %s' % argv)
         del argv[:count]
         return result

--- a/testrepository/commands/__init__.py
+++ b/testrepository/commands/__init__.py
@@ -38,7 +38,6 @@ import os
 import sys
 
 import subunit
-from testtools.compat import _u
 
 from testrepository.repository import file
 
@@ -204,8 +203,8 @@ def get_command_parser(cmd):
     parser = OptionParser()
     for option in cmd.options:
         parser.add_option(option)
-    usage = _u('%%prog %(cmd)s [options] %(args)s\n\n%(help)s') % {
-        'args': _u(' ').join(map(lambda x:x.summary(), cmd.args)),
+    usage = '%%prog %(cmd)s [options] %(args)s\n\n%(help)s' % {
+        'args': ' '.join(map(lambda x:x.summary(), cmd.args)),
         'cmd': getattr(cmd, 'name', cmd),
         'help': getdoc(cmd),
         }

--- a/testrepository/commands/list_tests.py
+++ b/testrepository/commands/list_tests.py
@@ -17,7 +17,6 @@
 from io import BytesIO
 
 from testtools import TestResult
-from testtools.compat import _b
 
 from testrepository.arguments.doubledash import DoubledashArgument
 from testrepository.arguments.string import StringArgument

--- a/testrepository/commands/run.py
+++ b/testrepository/commands/run.py
@@ -24,7 +24,6 @@ import testtools
 from testtools import (
     TestByTestResult,
     )
-from testtools.compat import _b
 
 from testrepository.arguments.doubledash import DoubledashArgument
 from testrepository.arguments.string import StringArgument
@@ -36,7 +35,7 @@ from testrepository.testcommand import TestCommand, testrconf_help
 from testrepository.testlist import parse_list
 
 
-LINEFEED = _b('\n')[0]
+LINEFEED = b'\n'[0]
 
 
 class ReturnCodeToSubunit(object):
@@ -74,7 +73,7 @@ class ReturnCodeToSubunit(object):
                 # line. V2 needs to start on any fresh utf8 character border
                 # - which is not guaranteed in an arbitrary stream endpoint, so
                 # injecting a \n gives us such a guarantee.
-                self.source.write(_b('\n'))
+                self.source.write(b'\n')
             stream = subunit.StreamResultToBytes(self.source)
             stream.status(test_id='process-returncode', test_status='fail',
                 file_name='traceback', mime_type='text/plain;charset=utf8',
@@ -84,7 +83,7 @@ class ReturnCodeToSubunit(object):
 
     def read(self, count=-1):
         if count == 0:
-            return _b('')
+            return b''
         result = self.source.read(count)
         if result:
             self.lastoutput = result[-1]

--- a/testrepository/repository/file.py
+++ b/testrepository/repository/file.py
@@ -28,7 +28,6 @@ import tempfile
 import subunit.v2
 from subunit import TestProtocolClient
 import testtools
-from testtools.compat import _b
 
 from testrepository.repository import (
     AbstractRepository,
@@ -123,7 +122,7 @@ class Repository(AbstractRepository):
         except IOError:
             err = sys.exc_info()[1]
             if err.errno == errno.ENOENT:
-                run_subunit_content = _b('')
+                run_subunit_content = b''
             else:
                 raise
         return _DiskRun(None, run_subunit_content)

--- a/testrepository/testlist.py
+++ b/testrepository/testlist.py
@@ -19,8 +19,6 @@ from io import BytesIO
 from subunit import ByteStreamToStreamResult
 from testtools.testresult.doubles import StreamResult
 
-from testtools.compat import _b, _u
-
 
 def write_list(stream, test_ids):
     """Write test_ids out to stream.
@@ -28,13 +26,12 @@ def write_list(stream, test_ids):
     :param stream: A file-like object.
     :param test_ids: An iterable of test ids.
     """
-    # May need utf8 explicitly?
-    stream.write(_b('\n'.join(list(test_ids) + [''])))
+    stream.write(('\n'.join(list(test_ids) + [''])).encode('utf8'))
 
 
 def parse_list(list_bytes):
     """Parse list_bytes into a list of test ids."""
-    return [id.strip() for id in list_bytes.decode('utf8').split(_u('\n'))
+    return [id.strip() for id in list_bytes.decode('utf8').split('\n')
             if id.strip()]
 
 

--- a/testrepository/tests/commands/test_failing.py
+++ b/testrepository/tests/commands/test_failing.py
@@ -19,7 +19,6 @@ from io import BytesIO
 
 from subunit.v2 import ByteStreamToStreamResult
 import testtools
-from testtools.compat import _b
 from testtools.matchers import (
     DocTestMatches,
     Equals,
@@ -110,7 +109,7 @@ class TestCommand(ResourcedTestCase):
         self.assertEqual(0, cmd.execute())
         self.assertEqual(1, len(ui.outputs))
         self.assertEqual('stream', ui.outputs[0][0])
-        self.assertThat(ui.outputs[0][1], Equals(_b('')))
+        self.assertThat(ui.outputs[0][1], Equals(b''))
 
     def test_with_list_shows_list_of_tests(self):
         ui, cmd = self.get_test_ui_and_cmd(options=[('list', True)])

--- a/testrepository/tests/commands/test_list_tests.py
+++ b/testrepository/tests/commands/test_list_tests.py
@@ -19,7 +19,6 @@ import os.path
 from subprocess import PIPE
 
 import subunit
-from testtools.compat import _b
 from testtools.matchers import MatchesException
 
 from testrepository.commands import list_tests
@@ -91,7 +90,7 @@ class TestCommand(ResourcedTestCase):
             ('popen', (expected_cmd,),
              {'shell': True, 'stdout': PIPE, 'stdin': PIPE}),
             ('communicate',),
-            ('stream', _b('returned\nvalues\n')),
+            ('stream', b'returned\nvalues\n'),
             ], ui.outputs)
 
     def test_filters_use_filtered_list(self):
@@ -116,6 +115,6 @@ class TestCommand(ResourcedTestCase):
             ('popen', (expected_cmd,),
              {'shell': True, 'stdout': PIPE, 'stdin': PIPE}),
             ('communicate',),
-            ('stream', _b('returned\n')),
+            ('stream', b'returned\n'),
             ], ui.outputs)
         self.assertEqual(0, retcode)

--- a/testrepository/tests/commands/test_load.py
+++ b/testrepository/tests/commands/test_load.py
@@ -22,7 +22,6 @@ import subunit
 import iso8601
 
 import testtools
-from testtools.compat import _b
 from testtools.content import text_content
 from testtools.matchers import MatchesException
 from testtools.tests.helpers import LoggingResult
@@ -42,7 +41,7 @@ from testrepository.repository import memory, RepositoryNotFound
 class TestCommandLoad(ResourcedTestCase):
 
     def test_load_loads_subunit_stream_to_default_repository(self):
-        ui = UI([('subunit', _b(''))])
+        ui = UI([('subunit', b'')])
         cmd = load.load(ui)
         ui.set_command(cmd)
         calls = []
@@ -61,7 +60,7 @@ class TestCommandLoad(ResourcedTestCase):
     def test_load_loads_named_file_if_given(self):
         datafile = NamedTemporaryFile()
         self.addCleanup(datafile.close)
-        ui = UI([('subunit', _b(''))], args=[datafile.name])
+        ui = UI([('subunit', b'')], args=[datafile.name])
         cmd = load.load(ui)
         ui.set_command(cmd)
         calls = []
@@ -80,7 +79,7 @@ class TestCommandLoad(ResourcedTestCase):
         self.assertEqual(1, repo.count())
 
     def test_load_initialises_repo_if_doesnt_exist_and_init_forced(self):
-        ui = UI([('subunit', _b(''))], options=[('force_init', True)])
+        ui = UI([('subunit', b'')], options=[('force_init', True)])
         cmd = load.load(ui)
         ui.set_command(cmd)
         calls = []
@@ -91,7 +90,7 @@ class TestCommandLoad(ResourcedTestCase):
         self.assertEqual([('open', ui.here), ('initialise', ui.here)], calls)
 
     def test_load_errors_if_repo_doesnt_exist(self):
-        ui = UI([('subunit', _b(''))])
+        ui = UI([('subunit', b'')])
         cmd = load.load(ui)
         ui.set_command(cmd)
         calls = []
@@ -105,7 +104,7 @@ class TestCommandLoad(ResourcedTestCase):
             ui.outputs[0][1], MatchesException(RepositoryNotFound('memory:')))
 
     def test_load_returns_0_normally(self):
-        ui = UI([('subunit', _b(''))])
+        ui = UI([('subunit', b'')])
         cmd = load.load(ui)
         ui.set_command(cmd)
         cmd.repository_factory = memory.RepositoryFactory()
@@ -190,7 +189,7 @@ class TestCommandLoad(ResourcedTestCase):
             ui.outputs)
 
     def test_load_new_shows_test_summary_no_tests(self):
-        ui = UI([('subunit', _b(''))])
+        ui = UI([('subunit', b'')])
         cmd = load.load(ui)
         ui.set_command(cmd)
         cmd.repository_factory = memory.RepositoryFactory()
@@ -202,7 +201,7 @@ class TestCommandLoad(ResourcedTestCase):
             ui.outputs)
 
     def test_load_quiet_shows_nothing(self):
-        ui = UI([('subunit', _b(''))], [('quiet', True)])
+        ui = UI([('subunit', b'')], [('quiet', True)])
         cmd = load.load(ui)
         ui.set_command(cmd)
         cmd.repository_factory = memory.RepositoryFactory()
@@ -225,7 +224,7 @@ class TestCommandLoad(ResourcedTestCase):
         self.assertEqual(1, ret)
 
     def test_partial_passed_to_repo(self):
-        ui = UI([('subunit', _b(''))], [('quiet', True), ('partial', True)])
+        ui = UI([('subunit', b'')], [('quiet', True), ('partial', True)])
         cmd = load.load(ui)
         ui.set_command(cmd)
         cmd.repository_factory = memory.RepositoryFactory()

--- a/testrepository/tests/commands/test_run.py
+++ b/testrepository/tests/commands/test_run.py
@@ -26,7 +26,6 @@ from fixtures import (
 import subunit
 from subunit import RemotedTestCase
 from testscenarios.scenarios import multiply_scenarios
-from testtools.compat import _b
 from testtools.matchers import (
     Equals,
     HasLength,
@@ -501,7 +500,7 @@ def readline(stream):
 
 
 def readlines(stream):
-    return _b('').join(stream.readlines())
+    return b''.join(stream.readlines())
 
 
 def accumulate(stream, reader):
@@ -510,7 +509,7 @@ def accumulate(stream, reader):
     while content:
         accumulator.append(content)
         content = reader(stream)
-    return _b('').join(accumulator)
+    return b''.join(accumulator)
 
 
 class TestReturnCodeToSubunit(ResourcedTestCase):
@@ -521,8 +520,8 @@ class TestReturnCodeToSubunit(ResourcedTestCase):
          ('readline', dict(reader=readline)),
          ('readlines', dict(reader=readlines)),
          ],
-        [('noeol', dict(stdout=_b('foo\nbar'))),
-         ('trailingeol', dict(stdout=_b('foo\nbar\n')))])
+        [('noeol', dict(stdout=b'foo\nbar')),
+         ('trailingeol', dict(stdout=b'foo\nbar\n'))])
 
     def test_returncode_0_no_change(self):
         proc = ProcessModel(None)

--- a/testrepository/tests/test_repository.py
+++ b/testrepository/tests/test_repository.py
@@ -32,7 +32,6 @@ from testtools import (
     PlaceHolder,
     )
 import testtools
-from testtools.compat import _b
 from testtools.testresult.doubles import (
     ExtendedTestResult,
     StreamResult,

--- a/testrepository/tests/test_testcommand.py
+++ b/testrepository/tests/test_testcommand.py
@@ -20,7 +20,6 @@ import optparse
 import re
 
 import subunit
-from testtools.compat import _b
 from testtools.matchers import (
     Equals,
     MatchesAny,
@@ -106,7 +105,7 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ntest_command=foo\n'
             'instance_dispose=bar $INSTANCE_IDS\n')
-        command._instances.update([_b('baz'), _b('quux')])
+        command._instances.update([b'baz', b'quux'])
         command.cleanUp()
         command.setUp()
         self.assertEqual([
@@ -120,7 +119,7 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ntest_command=foo\n'
             'instance_dispose=bar $INSTANCE_IDS\n')
-        command._instances.update([_b('baz'), _b('quux')])
+        command._instances.update([b'baz', b'quux'])
         self.assertThat(command.cleanUp,
             raises(ValueError('Disposing of instances failed, return 1')))
         command.setUp()
@@ -246,7 +245,7 @@ class TestTestCommand(ResourcedTestCase):
         ui.here = self.tempdir
         cmd = run.run(ui)
         ui.set_command(cmd)
-        ui.proc_outputs = [_b('returned\ninstances\n')]
+        ui.proc_outputs = [b'returned\ninstances\n']
         command = self.useFixture(TestCommand(ui, None))
         self.set_config(
             '[DEFAULT]\ntest_command=foo $LISTOPT $IDLIST\ntest_id_list_default=whoo yea\n'
@@ -255,7 +254,7 @@ class TestTestCommand(ResourcedTestCase):
             'instance_execute=quux $INSTANCE_ID -- $COMMAND\n')
         fixture = self.useFixture(command.get_run_command(test_ids=['1']))
         fixture.list_tests()
-        self.assertEqual(set([_b('returned'), _b('instances')]), command._instances)
+        self.assertEqual(set([b'returned', b'instances']), command._instances)
         self.assertEqual(set([]), command._allocated_instances)
         self.assertThat(ui.outputs, MatchesAny(Equals([
             ('values', [('running', 'provision -c 2')]),
@@ -280,9 +279,9 @@ class TestTestCommand(ResourcedTestCase):
             'test_list_option=--list\n'
             'instance_execute=quux $INSTANCE_ID -- $COMMAND\n')
         fixture = self.useFixture(command.get_run_command())
-        command._instances.add(_b('bar'))
+        command._instances.add(b'bar')
         fixture.list_tests()
-        self.assertEqual(set([_b('bar')]), command._instances)
+        self.assertEqual(set([b'bar']), command._instances)
         self.assertEqual(set([]), command._allocated_instances)
         self.assertEqual([
             ('values', [('running', 'quux bar -- foo --list whoo yea')]),
@@ -419,7 +418,7 @@ class TestTestCommand(ResourcedTestCase):
         ui, command = self.get_test_ui_and_cmd()
         self.set_config(
             '[DEFAULT]\ntest_command=foo $IDLIST\n')
-        command._instances.update([_b('foo'), _b('bar')])
+        command._instances.update([b'foo', b'bar'])
         fixture = self.useFixture(command.get_run_command())
         procs = fixture.run_tests()
         self.assertEqual([
@@ -434,7 +433,7 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ntest_command=foo $IDLIST\n'
             'instance_execute=quux $INSTANCE_ID -- $COMMAND\n')
-        command._instances.add(_b('bar'))
+        command._instances.add(b'bar')
         fixture = self.useFixture(command.get_run_command(test_ids=['1']))
         procs = fixture.run_tests()
         self.assertEqual([
@@ -443,13 +442,13 @@ class TestTestCommand(ResourcedTestCase):
              {'shell': True, 'stdin': -1, 'stdout': -1})],
             ui.outputs)
         # No --parallel, so the one instance should have been allocated.
-        self.assertEqual(set([_b('bar')]), command._instances)
-        self.assertEqual(set([_b('bar')]), command._allocated_instances)
+        self.assertEqual(set([b'bar']), command._instances)
+        self.assertEqual(set([b'bar']), command._allocated_instances)
         # And after the process is run, bar is returned for re-use.
         procs[0].stdout.read()
         procs[0].wait()
         self.assertEqual(0, procs[0].returncode)
-        self.assertEqual(set([_b('bar')]), command._instances)
+        self.assertEqual(set([b'bar']), command._instances)
         self.assertEqual(set(), command._allocated_instances)
         
     def test_run_tests_allocated_instances_skipped(self):
@@ -457,8 +456,8 @@ class TestTestCommand(ResourcedTestCase):
         self.set_config(
             '[DEFAULT]\ntest_command=foo $IDLIST\n'
             'instance_execute=quux $INSTANCE_ID -- $COMMAND\n')
-        command._instances.update([_b('bar'), _b('baz')])
-        command._allocated_instances.add(_b('baz'))
+        command._instances.update([b'bar', b'baz'])
+        command._allocated_instances.add(b'baz')
         fixture = self.useFixture(command.get_run_command(test_ids=['1']))
         procs = fixture.run_tests()
         self.assertEqual([
@@ -467,21 +466,21 @@ class TestTestCommand(ResourcedTestCase):
              {'shell': True, 'stdin': -1, 'stdout': -1})],
             ui.outputs)
         # No --parallel, so the one instance should have been allocated.
-        self.assertEqual(set([_b('bar'), _b('baz')]), command._instances)
-        self.assertEqual(set([_b('bar'), _b('baz')]), command._allocated_instances)
+        self.assertEqual(set([b'bar', b'baz']), command._instances)
+        self.assertEqual(set([b'bar', b'baz']), command._allocated_instances)
         # And after the process is run, bar is returned for re-use.
         procs[0].wait()
         procs[0].stdout.read()
         self.assertEqual(0, procs[0].returncode)
-        self.assertEqual(set([_b('bar'), _b('baz')]), command._instances)
-        self.assertEqual(set([_b('baz')]), command._allocated_instances)
+        self.assertEqual(set([b'bar', b'baz']), command._instances)
+        self.assertEqual(set([b'baz']), command._allocated_instances)
 
     def test_run_tests_list_file_in_FILES(self):
         ui, command = self.get_test_ui_and_cmd()
         self.set_config(
             '[DEFAULT]\ntest_command=foo $IDFILE\n'
             'instance_execute=quux $INSTANCE_ID $FILES -- $COMMAND\n')
-        command._instances.add(_b('bar'))
+        command._instances.add(b'bar')
         fixture = self.useFixture(command.get_run_command(test_ids=['1']))
         list_file = fixture.list_file_name
         procs = fixture.run_tests()
@@ -492,12 +491,12 @@ class TestTestCommand(ResourcedTestCase):
              {'shell': True, 'stdin': -1, 'stdout': -1})],
             ui.outputs)
         # No --parallel, so the one instance should have been allocated.
-        self.assertEqual(set([_b('bar')]), command._instances)
-        self.assertEqual(set([_b('bar')]), command._allocated_instances)
+        self.assertEqual(set([b'bar']), command._instances)
+        self.assertEqual(set([b'bar']), command._allocated_instances)
         # And after the process is run, bar is returned for re-use.
         procs[0].stdout.read()
         self.assertEqual(0, procs[0].returncode)
-        self.assertEqual(set([_b('bar')]), command._instances)
+        self.assertEqual(set([b'bar']), command._instances)
         self.assertEqual(set(), command._allocated_instances)
 
     def test_filter_tags_parsing(self):
@@ -507,7 +506,7 @@ class TestTestCommand(ResourcedTestCase):
 
     def test_callout_concurrency(self):
         ui, command = self.get_test_ui_and_cmd()
-        ui.proc_outputs = [_b('4')]
+        ui.proc_outputs = [b'4']
         self.set_config(
             '[DEFAULT]\ntest_run_concurrency=probe\n'
             'test_command=foo\n')
@@ -556,7 +555,7 @@ class TestTestCommand(ResourcedTestCase):
 
     def test_filter_tests_by_regex_supplied_ids(self):
         ui, command = self.get_test_ui_and_cmd()
-        ui.proc_outputs = [_b('returned\nids\n')]
+        ui.proc_outputs = [b'returned\nids\n']
         self.set_config(
             '[DEFAULT]\ntest_command=foo $LISTOPT $IDLIST\ntest_id_list_default=whoo yea\n'
             'test_list_option=--list\n')
@@ -567,7 +566,7 @@ class TestTestCommand(ResourcedTestCase):
 
     def test_filter_tests_by_regex_supplied_ids_multi_match(self):
         ui, command = self.get_test_ui_and_cmd()
-        ui.proc_outputs = [_b('returned\nids\n')]
+        ui.proc_outputs = [b'returned\nids\n']
         self.set_config(
             '[DEFAULT]\ntest_command=foo $LISTOPT $IDLIST\ntest_id_list_default=whoo yea\n'
             'test_list_option=--list\n')

--- a/testrepository/tests/test_ui.py
+++ b/testrepository/tests/test_ui.py
@@ -20,7 +20,6 @@ import subprocess
 import sys
 
 from fixtures import EnvironmentVariable
-from testtools.compat import _b, _u
 from testtools.content import text_content
 from testtools.matchers import raises
 
@@ -78,7 +77,7 @@ class TestUIContract(ResourcedTestCase):
         ui = self.ui_factory()
 
     def test_factory_input_stream_args(self):
-        ui = self.ui_factory([('subunit', _b('value'))])
+        ui = self.ui_factory([('subunit', b'value')])
 
     def test_here(self):
         ui = self.get_test_ui()
@@ -87,14 +86,14 @@ class TestUIContract(ResourcedTestCase):
     def test_iter_streams_load_stdin_use_case(self):
         # A UI can be asked for the streams that a command has indicated it
         # accepts, which is what load < foo will require.
-        ui = self.ui_factory([('subunit', _b('test: foo\nsuccess: foo\n'))])
+        ui = self.ui_factory([('subunit', b'test: foo\nsuccess: foo\n')])
         cmd = commands.Command(ui)
         cmd.input_streams = ['subunit+']
         ui.set_command(cmd)
         results = []
         for result in ui.iter_streams('subunit'):
             results.append(result.read())
-        self.assertEqual([_b('test: foo\nsuccess: foo\n')], results)
+        self.assertEqual([b'test: foo\nsuccess: foo\n'], results)
 
     def test_iter_streams_unexpected_type_raises(self):
         ui = self.get_test_ui()
@@ -112,7 +111,7 @@ class TestUIContract(ResourcedTestCase):
     def test_output_rest(self):
         # output some ReST - used for help and docs.
         ui = self.get_test_ui()
-        ui.output_rest(_u(''))
+        ui.output_rest('')
 
     def test_output_stream(self):
         # a stream of bytes can be output.
@@ -122,7 +121,7 @@ class TestUIContract(ResourcedTestCase):
     def test_output_stream_non_utf8(self):
         # When the stream has non-utf8 bytes it still outputs correctly.
         ui = self.get_test_ui()
-        ui.output_stream(BytesIO(_b('\xfa')))
+        ui.output_stream(BytesIO(b'\xfa'))
 
     def test_output_table(self):
         # output_table shows a table.

--- a/testrepository/tests/ui/test_cli.py
+++ b/testrepository/tests/ui/test_cli.py
@@ -26,7 +26,6 @@ from fixtures import EnvironmentVariable
 import subunit
 import testtools
 from testtools import TestCase
-from testtools.compat import _b, _u
 from testtools.matchers import (
     DocTestMatches,
     MatchesException,
@@ -68,7 +67,7 @@ class TestCLIUI(ResourcedTestCase):
 
     def test_stream_comes_from_stdin(self):
         stdout = BytesIO()
-        stdin = BytesIO(_b('foo\n'))
+        stdin = BytesIO(b'foo\n')
         stderr = BytesIO()
         ui = cli.UI([], stdin, stdout, stderr)
         cmd = commands.Command(ui)
@@ -77,13 +76,13 @@ class TestCLIUI(ResourcedTestCase):
         results = []
         for stream in ui.iter_streams('subunit'):
             results.append(stream.read())
-        self.assertEqual([_b('foo\n')], results)
+        self.assertEqual([b'foo\n'], results)
 
     def test_stream_type_honoured(self):
         # The CLI UI has only one stdin, so when a command asks for a stream
         # type it didn't declare, no streams are found.
         stdout = BytesIO()
-        stdin = BytesIO(_b('foo\n'))
+        stdin = BytesIO(b'foo\n')
         stderr = BytesIO()
         ui = cli.UI([], stdin, stdout, stderr)
         cmd = commands.Command(ui)
@@ -96,7 +95,7 @@ class TestCLIUI(ResourcedTestCase):
 
     def test_dash_d_sets_here_option(self):
         stdout = BytesIO()
-        stdin = BytesIO(_b('foo\n'))
+        stdin = BytesIO(b'foo\n')
         stderr = BytesIO()
         ui = cli.UI(['-d', '/nowhere/'], stdin, stdout, stderr)
         cmd = commands.Command(ui)
@@ -133,7 +132,7 @@ class TestCLIUI(ResourcedTestCase):
         # - this code is the most pragmatic to test on 2.6 and up, and 3.2 and
         # up.
         stdout = StringIO()
-        stdin = StringIO(_u('c\n'))
+        stdin = StringIO('c\n')
         stderr = StringIO()
         ui = cli.UI([], stdin, stdout, stderr)
         ui.output_error(err_tuple)
@@ -142,8 +141,8 @@ class TestCLIUI(ResourcedTestCase):
 
     def test_outputs_rest_to_stdout(self):
         ui, cmd = get_test_ui_and_cmd()
-        ui.output_rest(_u('topic\n=====\n'))
-        self.assertEqual(_b('topic\n=====\n'), ui._stdout.buffer.getvalue())
+        ui.output_rest('topic\n=====\n')
+        self.assertEqual(b'topic\n=====\n', ui._stdout.buffer.getvalue())
 
     def test_outputs_results_to_stdout(self):
         ui, cmd = get_test_ui_and_cmd()
@@ -167,14 +166,14 @@ AssertionError: quux...
 
     def test_outputs_stream_to_stdout(self):
         ui, cmd = get_test_ui_and_cmd()
-        stream = BytesIO(_b("Foo \n bar"))
+        stream = BytesIO(b"Foo \n bar")
         ui.output_stream(stream)
-        self.assertEqual(_b("Foo \n bar"), ui._stdout.buffer.getvalue())
+        self.assertEqual(b"Foo \n bar", ui._stdout.buffer.getvalue())
 
     def test_outputs_tables_to_stdout(self):
         ui, cmd = get_test_ui_and_cmd()
         ui.output_table([('foo', 1), ('b', 'quux')])
-        self.assertEqual(_b('foo  1\n---  ----\nb    quux\n'),
+        self.assertEqual(b'foo  1\n---  ----\nb    quux\n',
             ui._stdout.buffer.getvalue())
 
     def test_outputs_tests_to_stdout(self):
@@ -189,14 +188,14 @@ AssertionError: quux...
     def test_outputs_values_to_stdout(self):
         ui, cmd = get_test_ui_and_cmd()
         ui.output_values([('foo', 1), ('bar', 'quux')])
-        self.assertEqual(_b('foo=1, bar=quux\n'), ui._stdout.buffer.getvalue())
+        self.assertEqual(b'foo=1, bar=quux\n', ui._stdout.buffer.getvalue())
 
     def test_outputs_summary_to_stdout(self):
         ui, cmd = get_test_ui_and_cmd()
         summary = [True, 1, None, 2, None, []]
         expected_summary = ui._format_summary(*summary)
         ui.output_summary(*summary)
-        self.assertEqual(_b("%s\n" % (expected_summary,)),
+        self.assertEqual(("%s\n" % (expected_summary,)).encode('utf8'),
             ui._stdout.buffer.getvalue())
 
     def test_parse_error_goes_to_stderr(self):
@@ -363,7 +362,7 @@ class TestCLITestResult(TestCase):
         stream = TextIOWrapper(bytestream, 'utf8', line_buffering=True)
         ui = cli.UI(None, None, None, None)
         cli.CLITestResult(ui, stream, lambda: None)
-        self.assertEqual(_b(''), bytestream.getvalue())
+        self.assertEqual(b'', bytestream.getvalue())
 
     def test_format_error(self):
         # CLITestResult formats errors by giving them a big fat line, a title
@@ -408,7 +407,7 @@ class TestCLITestResult(TestCase):
         result.status(test_id='foo', test_status='fail', file_name='traceback',
             mime_type='text/plain;charset=utf8',
             file_bytes=b'-->\xe2\x80\x9c<--', eof=True)
-        pattern = _u("...-->?<--...")
+        pattern = "...-->?<--..."
         self.assertThat(
             stream.getvalue().decode('utf8'),
             DocTestMatches(pattern, doctest.ELLIPSIS))

--- a/testrepository/ui/cli.py
+++ b/testrepository/ui/cli.py
@@ -22,7 +22,7 @@ import sys
 
 import testtools
 from testtools import ExtendedToStreamDecorator, StreamToExtendedDecorator
-from testtools.compat import unicode_output_stream, _u
+from testtools.compat import unicode_output_stream
 
 from testrepository import ui
 from testrepository.commands import get_command_parser
@@ -41,19 +41,19 @@ class CLITestResult(ui.BaseUITestResult):
         """
         super(CLITestResult, self).__init__(ui, get_id, previous_run)
         self.stream = unicode_output_stream(stream)
-        self.sep1 = _u('=' * 70 + '\n')
-        self.sep2 = _u('-' * 70 + '\n')
+        self.sep1 = '=' * 70 + '\n'
+        self.sep2 = '-' * 70 + '\n'
         self.filter_tags = filter_tags or frozenset()
         self.filterable_states = set(['success', 'uxsuccess', 'xfail', 'skip'])
 
     def _format_error(self, label, test, error_text, test_tags=None):
         test_tags = test_tags or ()
-        tags = _u(' ').join(test_tags)
+        tags = ' '.join(test_tags)
         if tags:
-            tags = _u('tags: %s\n') % tags
-        return _u('').join([
+            tags = 'tags: %s\n' % tags
+        return ''.join([
             self.sep1,
-            _u('%s: %s\n') % (label, test.id()),
+            '%s: %s\n' % (label, test.id()),
             tags,
             self.sep2,
             error_text,
@@ -68,7 +68,7 @@ class CLITestResult(ui.BaseUITestResult):
             mime_type=mime_type, route_code=route_code, timestamp=timestamp)
         if test_status == 'fail':
             self.stream.write(
-                self._format_error(_u('FAIL'), *(self._summary.errors[-1]),
+                self._format_error('FAIL', *(self._summary.errors[-1]),
                 test_tags=test_tags))
         if test_status not in self.filterable_states:
             return
@@ -124,30 +124,19 @@ class UI(ui.AbstractUI):
     def output_error(self, error_tuple):
         if 'TESTR_PDB' in os.environ:
             import traceback
-            self._stderr.write(_u('').join(traceback.format_tb(error_tuple[2])))
-            self._stderr.write(_u('\n'))
-            # This is terrible: it is because on Python2.x pdb writes bytes to
-            # its pipes, and the test suite uses io.StringIO that refuse bytes.
-            import pdb;
-            if sys.version_info[0]==2:
-                if isinstance(self._stdout, io.StringIO):
-                    write = self._stdout.write
-                    def _write(text):
-                        return write(text.decode('utf8'))
-                    self._stdout.write = _write
+            self._stderr.write(''.join(traceback.format_tb(error_tuple[2])))
+            self._stderr.write('\n')
+            import pdb
             p = pdb.Pdb(stdin=self._stdin, stdout=self._stdout)
             p.reset()
             p.interaction(None, error_tuple[2])
         error_type = str(error_tuple[1])
-        # XX: Python2.
-        if type(error_type) is bytes:
-            error_type = error_type.decode('utf8')
-        self._stderr.write(error_type + _u('\n'))
+        self._stderr.write(error_type + '\n')
 
     def output_rest(self, rest_string):
         self._stdout.write(rest_string)
         if not rest_string.endswith('\n'):
-            self._stdout.write(_u('\n'))
+            self._stdout.write('\n')
 
     def output_stream(self, stream):
         if not self._binary_stdout:
@@ -198,22 +187,18 @@ class UI(ui.AbstractUI):
             outputs.append('  ')
         for row in contents[1:]:
             show_row(row)
-        self._stdout.write(_u('').join(outputs))
+        self._stdout.write(''.join(outputs))
 
     def output_tests(self, tests):
         for test in tests:
-            # On Python 2.6 id() returns bytes.
-            id_str = test.id()
-            if type(id_str) is bytes:
-                id_str = id_str.decode('utf8')
-            self._stdout.write(id_str)
-            self._stdout.write(_u('\n'))
+            self._stdout.write(test.id())
+            self._stdout.write('\n')
 
     def output_values(self, values):
         outputs = []
         for label, value in values:
             outputs.append('%s=%s' % (label, value))
-        self._stdout.write(_u('%s\n' % ', '.join(outputs)))
+        self._stdout.write('%s\n' % ', '.join(outputs))
 
     def _format_summary(self, successful, tests, tests_delta,
                         time, time_delta, values):
@@ -248,14 +233,14 @@ class UI(ui.AbstractUI):
                 values_strings.append(value_str)
             a(', '.join(values_strings))
             a(')')
-        return _u('').join(summary)
+        return ''.join(summary)
 
     def output_summary(self, successful, tests, tests_delta,
                        time, time_delta, values):
         self._stdout.write(
             self._format_summary(
                 successful, tests, tests_delta, time, time_delta, values))
-        self._stdout.write(_u('\n'))
+        self._stdout.write('\n')
 
     def _check_cmd(self):
         parser = get_command_parser(self.cmd)
@@ -291,12 +276,12 @@ class UI(ui.AbstractUI):
             except ValueError:
                 exc_info = sys.exc_info()
                 failed = True
-                self._stderr.write(_u("%s\n") % str(exc_info[1]))
+                self._stderr.write("%s\n" % str(exc_info[1]))
                 break
         if not failed:
             self.arguments = parsed_args
             if args != []:
-                self._stderr.write(_u("Unexpected arguments: %r\n") % args)
+                self._stderr.write("Unexpected arguments: %r\n" % args)
         return not failed and args == []
 
     def _clear_SIGPIPE(self):


### PR DESCRIPTION
Python 2 is long obsolete, and cannot be CI tested in any reasonable way. Make official the current defacto situation.