### PR TITLE
Remove use of pytz in favour of datetime.timezone.utc

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,9 @@ CHANGES
 
 * Drop Python 2 support. (Colin Watson)
 
+* Remove use of pytz in favour of ``datetime.timezone.utc``.
+  (Colin Watson, https://github.com/testing-cabal/testrepository/issues/56)
+
 0.0.21
 ++++++
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ license-files = ["COPYING"]
 
 [project.optional-dependencies]
 docs = ["sphinx"]
-test = ["pytz", "testresources", "testscenarios"]
+test = ["testresources", "testscenarios"]
 
 [tool.hatch.version]
 source = "vcs"

--- a/testrepository/tests/commands/test_slowest.py
+++ b/testrepository/tests/commands/test_slowest.py
@@ -17,8 +17,8 @@
 from datetime import (
     datetime,
     timedelta,
+    timezone,
 )
-import pytz
 
 from testtools import PlaceHolder
 
@@ -54,7 +54,7 @@ class TestCommand(ResourcedTestCase):
         :return: the name of the test that was added.
         """
         test_id = self.getUniqueString()
-        start_time = datetime.now(pytz.UTC)
+        start_time = datetime.now(timezone.utc)
         inserter.status(test_id=test_id, test_status='inprogress',
             timestamp=start_time)
         inserter.status(test_id=test_id, test_status='success',


### PR DESCRIPTION
Fixes: #56